### PR TITLE
Ecommerce tracking & checking status of the order

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -272,7 +272,7 @@ function gtm4wp_woocommerce_datalayer_filter_items( $dataLayer ) {
 			unset( $order );
 		}
 
-		if ( isset( $order ) ) {
+		if ( isset( $order ) && $order->is_paid() ) { // only if Order has paid status
 			if ( true === $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_WCTRACKCLASSICEC ] ) {
 				$dataLayer["transactionId"]             = $order->get_order_number();
 				$dataLayer["transactionDate"]           = date("c");


### PR DESCRIPTION
Hello

I am checking my ecommerce revenue in Analytics. And I am getting more revenue in Analytics than my revenue in Woocommerce.
It looks like my orders with "failed" status are being tracked.

GTM4WP doesn't check the status of the order, and for me it's the source of the bug.

I would suggest `$order->is_paid()` before tracking the ecommerce part.
Thank you
Nico