### PR TITLE
Travis CI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Editors
+project.xml
+project.properties
+/nbproject/private/
+.buildpath
+.project
+.settings*
+.idea
+.vscode
+*.sublime-project
+*.sublime-workspace
+.sublimelinterrc
+
+# OS X metadata
+.DS_Store
+
+# Windows junk
+Thumbs.db
+
+# Unit tests
+/tmp
+/tests/bin/tmp
+coverage.xml
+clover.xml
+
+# Composer
+/vendor/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,23 @@
+tools:
+  php_code_sniffer:
+    config:
+      standard: WordPress
+  sensiolabs_security_checker: true
+  external_code_coverage:
+    timeout: 2500
+checks:
+    php:
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: false
+        no_exit: false
+        coding_standard:
+            name: WordPress
+    javascript: true
+filter:
+  excluded_paths:
+    - tests/

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,6 +5,12 @@ tools:
   sensiolabs_security_checker: true
   external_code_coverage:
     timeout: 2500
+build:
+    nodes:
+        analysis:
+            dependencies:
+                before:
+                    - composer require --dev johnpbloch/wordpress
 checks:
     php:
         fix_php_opening_tag: false
@@ -21,3 +27,5 @@ checks:
 filter:
   excluded_paths:
     - tests/
+  dependency_paths:
+    - wordpress/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+sudo: false
 language: php
 
-branches:
-  only:
-    - master
+#branches:
+#  only:
+#    - master
 
 env:
   global:
@@ -12,13 +13,31 @@ env:
     - INSTALL_PHPUNIT=true
     - DB_HOST=localhost
     - PATH=${HOME}/bin:${PATH}
+    - WP_TEST_URL=http://localhost:12000
+    - WP_TEST_USER=test
+    - WP_TEST_USER_PASS=test
+    - WP_PROJECT_TYPE=plugin
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
       env: RUN_CS_FIXER=true
     - php: 7.0
     - php: 7.1
+    
+  allow_failures:
+    - php: nightly
+
+before_script:
+  # Install composer packages before trying to activate themes or plugins
+  # - composer install
+  - git clone https://github.com/Seravo/wordpress-test-template wp-tests
+  - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
 
 before_install:
   - pushd ${HOME}
+
+script:
+  - phpunit
+  - cd wp-tests/spec && bundle exec rspec test.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   on_failure: change
   email: false
 
-env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
+env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test WP_PLUGINLIST=woocommerce;amp
 
 php:
     #- 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 script:
   - phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
-  - cd tests/spec && bundle exec rspec test.rb
+  - cd spec && bundle exec rspec test.rb
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_script:
   # Composer support
   # - travis_retry composer self-update
   # - travis_retry composer install --no-interaction
+  # - composer require --dev johnpbloch/wordpress
+
 
   # Install composer packages before trying to activate themes or plugins
   # - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
 
 php:
-    - 5.4
+    #- 5.4
     - 5.5
     - 5.6
     - 7.0
@@ -46,4 +46,4 @@ after_script:
   - php ocular.phar code-coverage:upload --format=php-clover coverage.xml
   
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)https://developer.wordpress.org/cli/commands/plugin/install/in

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
 before_script:
   # Composer support
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction
 
   # Install composer packages before trying to activate themes or plugins
   # - composer install
@@ -47,4 +47,4 @@ script:
   - cd wp-tests/spec && bundle exec rspec test.rb
 
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
 script:
   - phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
-  - cd wp-tests/spec && bundle exec rspec test.rb
+  - cd tests/spec && bundle exec rspec test.rb
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
   # Install composer packages before trying to activate themes or plugins
   # - composer install
-  - git clone https://github.com/Seravo/wordpress-test-template wp-tests
+  - git clone https://github.com/fergbrain/wordpress-test-template wp-tests
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
 
 before_install:
@@ -48,6 +48,7 @@ before_install:
 script:
   - phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec test.rb
+  - phpcs --standard=WordPress ./**/*.php
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - pushd ${HOME}
 
 script:
-  - vendor/bin/phpunit --coverage-clover=coverage.xml
+  - phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec test.rb
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,15 @@ notifications:
   on_failure: change
   email: false
 
-env:
-  global:
-    - WP_VERSION=latest
-    - WP_MULTISITE=0
-    - TEST_BUILD_DIR=${TRAVIS_BUILD_DIR}
-    - INSTALL_PHPUNIT=true
-    - WP_TEST_URL=http://localhost:12000
-    - WP_TEST_USER=test
-    - WP_TEST_USER_PASS=test
-    - WP_PROJECT_TYPE=plugin
+env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
 
+
+TEST_BUILD_DIR=${TRAVIS_BUILD_DIR} INSTALL_PHPUNIT=true
 matrix:
   fast_finish: true
   include:
     - php: 5.6
+      dist: precise
     - php: 7.0
     - php: 7.1
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - WP_MULTISITE=0
     - TEST_BUILD_DIR=${TRAVIS_BUILD_DIR}
     - INSTALL_PHPUNIT=true
-    - DB_HOST=localhost
-    - PATH=${HOME}/bin:${PATH}
     - WP_TEST_URL=http://localhost:12000
     - WP_TEST_USER=test
     - WP_TEST_USER_PASS=test
@@ -22,7 +20,6 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
-      env: RUN_CS_FIXER=true
     - php: 7.0
     - php: 7.1
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ script:
   #- phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec *.rb
+  # Syntax check all php files and fail for any error text in STDERR
+  - '! find . -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,22 @@ matrix:
 before_script:
   # Install composer packages before trying to activate themes or plugins
   # - composer install
-  - git clone https://github.com/Koodimonni/wordpress-test-template wp-tests
+
+  # Install Wordpress testing suite and run wordpress
+  - git clone https://github.com/koconder/wordpress-test-template wp-tests
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
+
   # Test wordpress
   - curl -i http://localhost:12000
-  # Install gems for rspec tests
+
+  # Install gems for rspec tests and run
   - gem install bundler
-  - bundle install --gemfile=tests-rspec/Gemfile
+  - bundle install --gemfile=wp-tests/spec/Gemfile
 
 script:
   #- phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
-  - cd tests-rspec && bundle exec rspec *.rb
-
+  - cd wp-tests/spec && bundle exec rspec *.rb
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ notifications:
 
 env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
 
-
-TEST_BUILD_DIR=${TRAVIS_BUILD_DIR} INSTALL_PHPUNIT=true
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
 
   # Install composer packages before trying to activate themes or plugins
   # - composer install
-  - git clone https://github.com/fergbrain/wordpress-test-template wp-tests
+  - git clone https://github.com/koconder/wordpress-test-template wp-tests
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,15 @@ matrix:
       env: RUN_CS_FIXER=true
     - php: 7.0
     - php: 7.1
+    - hhvm
     
   allow_failures:
     - php: nightly
 
 before_script:
   # Composer support
-  - travis_retry composer self-update
-  - travis_retry composer install --no-interaction
+  # - travis_retry composer self-update
+  # - travis_retry composer install --no-interaction
 
   # Install composer packages before trying to activate themes or plugins
   # - composer install
@@ -48,3 +49,6 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+  
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: php
 #  only:
 #    - master
 
+notifications:
+  on_success: never
+  on_failure: change
+  email: false
+
 env:
   global:
     - WP_VERSION=latest
@@ -23,7 +28,7 @@ matrix:
     - php: 7.0
     - php: 7.1
     - hhvm
-    
+    - nightly
   allow_failures:
     - php: nightly
 
@@ -39,16 +44,10 @@ before_script:
   - git clone https://github.com/fergbrain/wordpress-test-template wp-tests
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
 
-before_install:
-  - pushd ${HOME}
-
 script:
+  - phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec test.rb
-  - phpcs --standard=WordPress ./**/*.php
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  
-notifications:
-  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: php
 
-#branches:
-#  only:
-#    - master
-
 notifications:
   on_success: never
   on_failure: change
@@ -17,6 +13,10 @@ matrix:
   include:
     - php: 5.6
       dist: precise
+    - php: 5.5
+      dist: precise
+    - php: 5.4
+      dist: precise
     - php: 7.0
     - php: 7.1
     - hhvm
@@ -25,21 +25,24 @@ matrix:
     - php: nightly
 
 before_script:
-  # Composer support
-  # - travis_retry composer self-update
-  # - travis_retry composer install --no-interaction
-  # - composer require --dev johnpbloch/wordpress
-
-
   # Install composer packages before trying to activate themes or plugins
   # - composer install
-  - git clone https://github.com/koconder/wordpress-test-template wp-tests
+  - git clone https://github.com/Koodimonni/wordpress-test-template wp-tests
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
+  # Test wordpress
+  - curl -i http://localhost:12000
+  # Install gems for rspec tests
+  - gem install bundler
+  - bundle install --gemfile=tests-rspec/Gemfile
 
 script:
-  - phpcs --standard=WordPress ./**/*.php
+  #- phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
-  - cd spec && bundle exec rspec test.rb
+  - cd tests-rspec && bundle exec rspec *.rb
+
+after_script:
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.xml
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,22 @@ notifications:
 
 env: WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 5.6
-      dist: precise
-    - php: 5.5
-      dist: precise
-    - php: 5.4
-      dist: precise
-    - php: 7.0
-    - php: 7.1
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
     - hhvm
     - nightly
+
+matrix:
+  fast_finish: true
   allow_failures:
     - php: nightly
+    - php: hhvm
+
+cache: bundler
 
 before_script:
   # Install composer packages before trying to activate themes or plugins
@@ -35,17 +36,14 @@ before_script:
   # Test wordpress
   - curl -i http://localhost:12000
 
-  # Install gems for rspec tests and run
-  - gem install bundler
-  - bundle install --gemfile=wp-tests/spec/Gemfile
-
 script:
   #- phpcs --standard=WordPress ./**/*.php
   - phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec *.rb
+
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.xml
-
+  
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
     - php: nightly
 
 before_script:
+  # Composer support
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source --dev
+
   # Install composer packages before trying to activate themes or plugins
   # - composer install
   - git clone https://github.com/Seravo/wordpress-test-template wp-tests
@@ -39,5 +43,8 @@ before_install:
   - pushd ${HOME}
 
 script:
-  - phpunit
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
   - cd wp-tests/spec && bundle exec rspec test.rb
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+  bootstrap="tests/bootstrap.php"
+  backupGlobals="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  >
+  <testsuites>
+    <testsuite>
+      <directory prefix="test-" suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
     <log type="coverage-clover" target="coverage.xml"/>
   </logging>
   <php>
+    <env name="PLUGIN_FILE" value="duracelltomi-google-tag-manager-for-wordpress.php"/>
     <ini name="display_errors" value="true"/>
     <ini name="display_startup_errors" value="true"/>
   </php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,4 +11,7 @@
       <directory prefix="test-" suffix=".php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <logging>
+    <log type="coverage-clover" target="clover.xml"/>
+  </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,8 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
+ 	verbose="true"
+	syntaxCheck="true"
   >
   <testsuites>
     <testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,4 +16,8 @@
   <logging>
     <log type="coverage-clover" target="coverage.xml"/>
   </logging>
+  <php>
+    <ini name="display_errors" value="true"/>
+    <ini name="display_startup_errors" value="true"/>
+  </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,6 @@
     </testsuite>
   </testsuites>
   <logging>
-    <log type="coverage-clover" target="clover.xml"/>
+    <log type="coverage-clover" target="coverage.xml"/>
   </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,17 @@
   </logging>
   <php>
     <env name="PLUGIN_FILE" value="duracelltomi-google-tag-manager-for-wordpress.php"/>
-    <ini name="display_errors" value="true"/>
+    <ini name="display_errors" value="false"/>
     <ini name="display_startup_errors" value="true"/>
   </php>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">./</directory>
+      <file>/path/to/file</file>
+      <exclude>
+        <directory suffix=".php">./</directory>
+        <file>/path/to/file</file>
+      </exclude>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,8 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
- 	verbose="true"
-	syntaxCheck="true"
+  verbose="true"
+  syntaxCheck="true"
   >
   <testsuites>
     <testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+define('PLUGIN_NAME','your-plugin-name-here.php');
+define('PLUGIN_FOLDER',basename(dirname( __DIR__ )));
+define('PLUGIN_PATH',PLUGIN_FOLDER.'/'.PLUGIN_NAME);
+
+// Activates this plugin in WordPress so it can be tested.
+$GLOBALS['wp_tests_options'] = array(
+  'active_plugins' => array( PLUGIN_PATH ),
+);
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __DIR__ ) . '/'.PLUGIN_NAME;
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,9 +5,12 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
-define('PLUGIN_NAME','duracelltomi-google-tag-manager-for-wordpress.php');
-define('PLUGIN_FOLDER',basename(dirname( __DIR__ )));
-define('PLUGIN_PATH',PLUGIN_FOLDER.'/'.PLUGIN_NAME);
+/**
+ * change PLUGIN_FILE env in phpunit.xml
+ */
+define('PLUGIN_FILE', getenv('PLUGIN_FILE') );
+define('PLUGIN_FOLDER', basename( dirname( __DIR__ ) ) );
+define('PLUGIN_PATH', PLUGIN_FOLDER.'/'.PLUGIN_FILE);
 
 // Activates this plugin in WordPress so it can be tested.
 $GLOBALS['wp_tests_options'] = array(
@@ -16,10 +19,12 @@ $GLOBALS['wp_tests_options'] = array(
 
 require_once $_tests_dir . '/includes/functions.php';
 
-function _manually_load_plugin() {
-	require dirname( __DIR__ ) . '/'.PLUGIN_NAME;
-}
-
+/*
+ * Activate this plugin automatically
+ */
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+function _manually_load_plugin() {
+	require dirname( __DIR__ ) . '/'. PLUGIN_FILE;
+}
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
-define('PLUGIN_NAME','your-plugin-name-here.php');
+define('PLUGIN_NAME','duracelltomi-google-tag-manager-for-wordpress.php');
 define('PLUGIN_FOLDER',basename(dirname( __DIR__ )));
 define('PLUGIN_PATH',PLUGIN_FOLDER.'/'.PLUGIN_NAME);
 

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -1,0 +1,7 @@
+<?php
+class PluginTest extends WP_UnitTestCase {
+  // Check that that activation doesn't break
+  function test_plugin_activated() {
+    $this->assertTrue( is_plugin_active( PLUGIN_PATH ) );
+  }
+}


### PR DESCRIPTION
Took a little while longer than expected, had to rebuild and fork the php testing suite for CI tools to https://github.com/koconder/wordpress-test-template - Rebuilt the entire setup to support testing of Wordpress, along with multi-plugin co-dependency and other CI tools support.

Should enable us to get build errors and PHP code coverage and issues via Scrutinizer. #64 will be resolve through this PR