### PR TITLE
Allow for optional echo of gtm4wp_wp_header_begin output

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -634,7 +634,7 @@ function gtm4wp_wp_header_top() {
 <!-- End Google Tag Manager for WordPress by DuracellTomi -->';
 }
 
-function gtm4wp_wp_header_begin() {
+function gtm4wp_wp_header_begin($echo = true) {
 	global $gtm4wp_datalayer_name, $gtm4wp_options;
 
 	$_gtm_header_content = '
@@ -720,7 +720,11 @@ j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
 	$_gtm_header_content .= '
 <!-- End Google Tag Manager for WordPress by DuracellTomi -->';
 
-	echo $_gtm_header_content;
+    if($echo) {
+      echo $_gtm_header_content;
+    }
+  
+    return $_gtm_header_content;
 }
 
 function gtm4wp_body_class( $classes ) {

--- a/public/frontend.php
+++ b/public/frontend.php
@@ -634,7 +634,7 @@ function gtm4wp_wp_header_top() {
 <!-- End Google Tag Manager for WordPress by DuracellTomi -->';
 }
 
-function gtm4wp_wp_header_begin($echo = true) {
+function gtm4wp_wp_header_begin( $echo = true ) {
 	global $gtm4wp_datalayer_name, $gtm4wp_options;
 
 	$_gtm_header_content = '
@@ -720,11 +720,11 @@ j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
 	$_gtm_header_content .= '
 <!-- End Google Tag Manager for WordPress by DuracellTomi -->';
 
-    if($echo) {
+    if ( $echo ) {
       echo $_gtm_header_content;
+    } else {
+      return $_gtm_header_content;
     }
-  
-    return $_gtm_header_content;
 }
 
 function gtm4wp_body_class( $classes ) {


### PR DESCRIPTION
I'm using your (most excellent) GTM4WP inside of the Automattic Facebook Instant Articles plugin. Right now, to capture the output of `gtm4wp_wp_header_begin` i'm having to use `ob_start` and friends. Adding this `$echo` variable to control echo while always returning the results of the function means I can kick `ob_start` to the curb.