### PR TITLE
Check settings for undefined

### DIFF
--- a/js/gtm4wp-woocommerce-enhanced.js
+++ b/js/gtm4wp-woocommerce-enhanced.js
@@ -398,7 +398,7 @@ jQuery(function() {
 
 	// initiate codes in WooCommere Quick View
 	jQuery( document ).ajaxSuccess( function( event, xhr, settings ) {
-		if ( settings.url.indexOf( 'wc-api=WC_Quick_View' ) > -1 ) {
+		if (settings != undefined && settings.url.indexOf( 'wc-api=WC_Quick_View' ) > -1 ) {
 		  setTimeout( function() {
 				jQuery( ".woocommerce.quick-view" ).parent().find( "script" ).each( function(i) {
 					eval( jQuery( this ).text() );

--- a/js/gtm4wp-woocommerce-enhanced.js
+++ b/js/gtm4wp-woocommerce-enhanced.js
@@ -398,12 +398,14 @@ jQuery(function() {
 
 	// initiate codes in WooCommere Quick View
 	jQuery( document ).ajaxSuccess( function( event, xhr, settings ) {
-		if (settings != undefined && settings.url.indexOf( 'wc-api=WC_Quick_View' ) > -1 ) {
-		  setTimeout( function() {
-				jQuery( ".woocommerce.quick-view" ).parent().find( "script" ).each( function(i) {
-					eval( jQuery( this ).text() );
-				});
-			}, 500);
+		if(typeof settings !== 'undefined') {
+			if (settings.url.indexOf( 'wc-api=WC_Quick_View' ) > -1 ) {
+			  setTimeout( function() {
+					jQuery( ".woocommerce.quick-view" ).parent().find( "script" ).each( function(i) {
+						eval( jQuery( this ).text() );
+					});
+				}, 500);
+			}
 		}
 	});
 


### PR DESCRIPTION
With some other plugins, that interfere with event processing, I get this error:
```
gtm4wp-woocommerce-enhanced.js:391 Uncaught TypeError: Cannot read property 'url' of undefined
    at HTMLDocument.<anonymous> (gtm4wp-woocommerce-enhanced.js:391)
    at HTMLDocument.dispatch (jquery.js:3)
    at HTMLDocument.r.handle (jquery.js:3)
    at HTMLDocument.<anonymous> (mango.js:formatted:5854)
    at mango.js:formatted:5205
    at m.every (<anonymous>)
    at m.each (mango.js:formatted:5204)
    at m.n.fn.trigger (mango.js:formatted:5853)
    at n (mango.js:formatted:5899)
    at r (mango.js:formatted:5904)
    at s (mango.js:formatted:5921)
    at HTMLScriptElement.<anonymous> (mango.js:formatted:5992)
    at HTMLScriptElement.i.proxy (mango.js:formatted:5692)
```