### PR TITLE
Fix for fatal error if Woocommerce isn't installed

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1403,7 +1403,7 @@ function gtm4wp_show_warning() {
 		$gtm4wp_def_user_notices_dismisses;
 
 	$woo_plugin_active = is_plugin_active( $gtm4wp_integratefieldtexts[ GTM4WP_OPTION_INTEGRATE_WCTRACKCLASSICEC ]['plugintocheck'] );
-	if ( $woo_plugin_active ) {
+	if ( $woo_plugin_active && function_exists( 'WC' ) ) {
 		$woo = WC();
 	} else {
 		$woo = null;


### PR DESCRIPTION
I have a site that's in development to add a Woocommerce component. The production site won't have Woocommerce installed for some time yet, my development server does. When switching between git branches for the production version of the site and the development version, gtm4wp gives a fatal error when the database thinks the plugin is active, but the plugin files aren't present. 

This simple fix just adds a `function_exists` call to the existing conditional checking if Woocommerce is active. This prevents a fatal error in this circumstance, and should not have any other impact on the plugin.

Thanks!