### PR TITLE
Ensure that variables are globals to be used everywhere.

### DIFF
--- a/common/readoptions.php
+++ b/common/readoptions.php
@@ -126,6 +126,8 @@ define( 'GTM4WP_PLACEMENT_BODYOPEN', 1 );
 define( 'GTM4WP_PLACEMENT_BODYOPEN_AUTO', 2 );
 define( 'GTM4WP_PLACEMENT_OFF', 3 );
 
+global $gtm4wp_options, $gtm4wp_defaultoptions;
+
 $gtm4wp_options = array();
 
 $gtm4wp_defaultoptions = array(


### PR DESCRIPTION
This fixes a bunch of notices I've been getting while setting up the plugin on a WP VIP environment.