### PR TITLE
add availability class into enhanced ecommerce data

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -139,6 +139,8 @@ function gtm4wp_process_product( $product, $additional_product_attributes, $attr
 	if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_WCUSESKU ] && ( '' != $product_sku ) ) {
 		$remarketing_id = $product_sku;
 	}
+	$avail = $product->get_availability();
+	$class = $avail['class'];
 
 	$_temp_productdata = array(
 		'id'         => $remarketing_id,
@@ -146,7 +148,8 @@ function gtm4wp_process_product( $product, $additional_product_attributes, $attr
 		'sku'        => $product_sku ? $product_sku : $product_id,
 		'category'   => $product_cat,
 		'price'      => (float) wc_get_price_to_display( $product ),
-		'stocklevel' => $product->get_stock_quantity()
+		'stocklevel' => $product->get_stock_quantity(),
+		'availability' => $class
 	);
 
 	if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_WCEECBRANDTAXONOMY ] != "" ) {
@@ -689,7 +692,7 @@ function gtm4wp_woocommerce_cart_item_remove_link_filter( $remove_from_cart_link
 	}
 
 	$cartlink_with_data                   = sprintf(
-		'data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_variant="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_brand="%s" href="',
+		'data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_variant="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_availability="%s" data-gtm4wp_product_brand="%s" href="',
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['id'] ),
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['name'] ),
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['price'] ),
@@ -697,6 +700,7 @@ function gtm4wp_woocommerce_cart_item_remove_link_filter( $remove_from_cart_link
 		esc_url( $GLOBALS['gtm4wp_cart_item_proddata']['productlink'] ),
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['variant'] ),
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['stocklevel'] ),
+		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['availability'] ),
 		esc_attr( $GLOBALS['gtm4wp_cart_item_proddata']['brand'] )
 	);
 	$GLOBALS['gtm4wp_cart_item_proddata'] = '';
@@ -756,7 +760,7 @@ function gtm4wp_woocommerce_after_template_part( $template_name ) {
 		}
 
 		$productlink_with_data = sprintf(
-			'data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_brand="%s" href="',
+			'data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_availability="%s" data-gtm4wp_product_brand="%s" href="',
 			esc_attr( $eec_product_array['id'] ),
 			esc_attr( $eec_product_array['name'] ),
 			esc_attr( $eec_product_array['price'] ),
@@ -765,6 +769,7 @@ function gtm4wp_woocommerce_after_template_part( $template_name ) {
 			esc_attr( $eec_product_array['listname'] ),
 			esc_attr( $eec_product_array['listposition'] ),
 			esc_attr( $eec_product_array['stocklevel'] ),
+			esc_attr( $eec_product_array['availability'] ),
 			esc_attr( $eec_product_array[ "brand" ] )
 		);
 
@@ -868,7 +873,7 @@ function gtm4wp_woocommerce_before_shop_loop_item() {
 	}
 
 	printf(
-		'<span class="gtm4wp_productdata" style="display:none; visibility:hidden;" data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_brand="%s"></span>',
+		'<span class="gtm4wp_productdata" style="display:none; visibility:hidden;" data-gtm4wp_product_id="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_availability="%s" data-gtm4wp_product_brand="%s"></span>',
 		esc_attr( $eec_product_array['id'] ),
 		esc_attr( $eec_product_array['name'] ),
 		esc_attr( $eec_product_array['price'] ),
@@ -877,6 +882,7 @@ function gtm4wp_woocommerce_before_shop_loop_item() {
 		esc_attr( $eec_product_array['listposition'] ),
 		esc_attr( $eec_product_array['listname'] ),
 		esc_attr( $eec_product_array['stocklevel'] ),
+		esc_attr( $eec_product_array['availability'] ),
 		esc_attr( $eec_product_array[ "brand" ] )
 	);
 }
@@ -986,7 +992,7 @@ function gtm4wp_woocommerce_grouped_product_list_column_label( $labelvalue, $pro
 
 	$labelvalue .=
 		sprintf(
-			'<span class="gtm4wp_productdata" style="display:none; visibility:hidden;" data-gtm4wp_product_id="%s" data-gtm4wp_product_sku="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_brand="%s"></span>',
+			'<span class="gtm4wp_productdata" style="display:none; visibility:hidden;" data-gtm4wp_product_id="%s" data-gtm4wp_product_sku="%s" data-gtm4wp_product_name="%s" data-gtm4wp_product_price="%s" data-gtm4wp_product_cat="%s" data-gtm4wp_product_url="%s" data-gtm4wp_product_listposition="%s" data-gtm4wp_productlist_name="%s" data-gtm4wp_product_stocklevel="%s" data-gtm4wp_product_availability="%s" data-gtm4wp_product_brand="%s"></span>',
 			esc_attr( $eec_product_array['id'] ),
 			esc_attr( $eec_product_array['sku'] ),
 			esc_attr( $eec_product_array['name'] ),
@@ -996,6 +1002,7 @@ function gtm4wp_woocommerce_grouped_product_list_column_label( $labelvalue, $pro
 			esc_attr( $eec_product_array['listposition'] ),
 			esc_attr( $eec_product_array['listname'] ),
 			esc_attr( $eec_product_array['stocklevel'] ),
+			esc_attr( $eec_product_array['availability'] ),
 			esc_attr( $eec_product_array['brand'] )
 		);
 

--- a/js/gtm4wp-woocommerce-enhanced.js
+++ b/js/gtm4wp-woocommerce-enhanced.js
@@ -36,6 +36,7 @@ function gtm4wp_handle_cart_qty_change() {
 								'category':   productdata.data( 'gtm4wp_product_cat' ),
 								'variant':    productdata.data( 'gtm4wp_product_variant' ),
 								'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+								'availability': productdata.data( 'gtm4wp_product_availability' ),
 								'brand':      productdata.data( 'gtm4wp_product_brand' ),
 								'quantity':   _current_value - _original_value
 							}]
@@ -55,6 +56,7 @@ function gtm4wp_handle_cart_qty_change() {
 								'category':   productdata.data( 'gtm4wp_product_cat' ),
 								'variant':    productdata.data( 'gtm4wp_product_variant' ),
 								'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+								'availability': productdata.data( 'gtm4wp_product_availability' ),
 								'brand':      productdata.data( 'gtm4wp_product_brand' ),
 								'quantity':   _original_value - _current_value
 							}]
@@ -95,6 +97,7 @@ jQuery(function() {
 				'position':   productdata.data( 'gtm4wp_product_listposition' ),
 				'list':       productdata.data( 'gtm4wp_productlist_name' ),
 				'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+				'availability': productdata.data( 'gtm4wp_product_availability' ),
 				'brand':      productdata.data( 'gtm4wp_product_brand' )
 			});
 
@@ -165,6 +168,7 @@ jQuery(function() {
 						'price':      productprice.toFixed(2),
 						'category':   productdata.data( 'gtm4wp_product_cat' ),
 						'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+						'availability': productdata.data( 'gtm4wp_product_availability' ),
 						'brand':      productdata.data( 'gtm4wp_product_brand' ),
 						'quantity':   1
 					}]
@@ -218,6 +222,7 @@ jQuery(function() {
 					'category':   productdata.data( 'gtm4wp_product_cat' ),
 					'quantity':   product_qty,
 					'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+					'availability': productdata.data( 'gtm4wp_product_availability' ),
 					'brand':      productdata.data( 'gtm4wp_product_brand' )
 				});
 			});
@@ -248,6 +253,7 @@ jQuery(function() {
 							'category':   jQuery( '[name=gtm4wp_category]', _product_form ).val(),
 							'quantity':   jQuery( 'form.cart:first input[name=quantity]' ).val(),
 							'stocklevel': jQuery( '[name=gtm4wp_stocklevel]', _product_form ).val(),
+							'availability': jQuery( '[name=gtm4wp_availability]', _product_form ).val(),
 							'brand':      jQuery( '[name=gtm4wp_brand]', _product_form ).val()
 						}]
 					}
@@ -290,6 +296,7 @@ jQuery(function() {
 						'category':   productdata.data( 'gtm4wp_product_cat' ),
 						'variant':    productdata.data( 'gtm4wp_product_variant' ),
 						'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+						'availability': productdata.data( 'gtm4wp_product_availability' ),
 						'brand':      productdata.data( 'gtm4wp_product_brand' ),
 						'quantity':   qty
 					}]
@@ -364,6 +371,7 @@ jQuery(function() {
 						'price':      productdata.data( 'gtm4wp_product_price' ),
 						'category':   productdata.data( 'gtm4wp_product_cat' ),
 						'stocklevel': productdata.data( 'gtm4wp_product_stocklevel' ),
+						'availability': productdata.data( 'gtm4wp_product_availability' ),
 						'brand':      productdata.data( 'gtm4wp_product_brand' ),
 						'position':   productdata.data( 'gtm4wp_product_listposition' )
 					}]
@@ -400,6 +408,7 @@ jQuery(function() {
 		var _product_category   = jQuery( '[name=gtm4wp_category]', _product_form ).val();
 		var _product_price      = jQuery( '[name=gtm4wp_price]', _product_form ).val();
 		var _product_stocklevel = jQuery( '[name=gtm4wp_stocklevel]', _product_form ).val();
+		var _product_availability = jQuery( '[name=gtm4wp_availability]', _product_form ).val();
 		var _product_brand      = jQuery( '[name=gtm4wp_brand]', _product_form ).val();
 
 		var current_product_detail_data   = {
@@ -408,6 +417,7 @@ jQuery(function() {
 			price: 0,
 			category: _product_category,
 			stocklevel: _product_stocklevel,
+			availability: _product_availability,
 			brand: _product_brand,
 			variant: ''
 		};


### PR DESCRIPTION
Hi, I needed to add this field, as Google Merchant feeds need the availability information (in-stock, out-of-stock, preorder) to work.
https://support.google.com/merchants/answer/7052112?visit_id=637160617968731847-439547322&rd=1
I hope this is helpful so you can add it to your plugin, which is so useful, thank you!

Pilar