### PR TITLE
Correct assumption made in constant warning messages

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -488,7 +488,7 @@ function gtm4wp_admin_output_field( $args ) {
 			if ( defined( 'GTM4WP_HARDCODED_GTM_ID' ) ) {
 				$_gtm_id_value   = GTM4WP_HARDCODED_GTM_ID;
 				$_input_readonly = ' readonly="readonly"';
-				$_warning_after  = '<br /><span class="gtm_wpconfig_set">WARNING! Container ID was set and fixed in wp-config.php. If you wish to change this value, please edit your wp-config.php and change the container ID or remove the GTM4WP_HARDCODED_GTM_ID constant!</span>';
+				$_warning_after  = '<br /><span class="gtm_wpconfig_set">WARNING! Container ID was set and fixed by the GTM4WP_HARDCODED_GTM_ID constant: check wp-config.php, plugins, and your theme settings to change or remove the container ID.</span>';
 			} else {
 				$_gtm_id_value   = $gtm4wp_options[ GTM4WP_OPTION_GTM_CODE ];
 				$_input_readonly = '';
@@ -522,7 +522,7 @@ function gtm4wp_admin_output_field( $args ) {
 			if ( defined( 'GTM4WP_HARDCODED_GTM_ENV_AUTH' ) ) {
 				$_gtm_auth_value = GTM4WP_HARDCODED_GTM_ENV_AUTH;
 				$_input_readonly = ' readonly="readonly"';
-				$_warning_after  = '<br /><span class="gtm_wpconfig_set">WARNING! Environment auth parameter was set and fixed in wp-config.php. If you wish to change this value, please edit your wp-config.php and change the parameter value or remove the GTM4WP_HARDCODED_GTM_ENV_AUTH constant!</span>';
+				$_warning_after  = '<br /><span class="gtm_wpconfig_set">WARNING! Environment auth parameter was set and fixed by the GTM4WP_HARDCODED_GTM_ENV_AUTH constant: check wp-config.php, plugins, and your theme settings to change or remove the environment auth parameter.</span>';
 			} else {
 				$_gtm_auth_value = $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_AUTH ];
 				$_input_readonly = '';
@@ -540,7 +540,7 @@ function gtm4wp_admin_output_field( $args ) {
 			if ( defined( 'GTM4WP_HARDCODED_GTM_ENV_PREVIEW' ) ) {
 				$_gtm_preview_value = GTM4WP_HARDCODED_GTM_ENV_PREVIEW;
 				$_input_readonly    = ' readonly="readonly"';
-				$_warning_after     = '<br /><span class="gtm_wpconfig_set">WARNING! Environment preview parameter was set and fixed in wp-config.php. If you wish to change this value, please edit your wp-config.php and change the parameter value or remove the GTM4WP_HARDCODED_GTM_ENV_PREVIEW constant!</span>';
+				$_warning_after     = '<br /><span class="gtm_wpconfig_set">WARNING! Environment preview parameter was set and fixed by the GTM4WP_HARDCODED_GTM_ENV_PREVIEW constant: check wp-config.php, plugins, and your theme settings to change or remove the environment preview parameter.</span>';
 			} else {
 				$_gtm_preview_value = $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_PREVIEW ];
 				$_input_readonly    = '';


### PR DESCRIPTION
In 9d9e116bf692dd183fc90a8b2b03a6b205564f42 (#133), constants were added to allow for the hard-coding of container and environment IDs 🎉 . This included a warning message directly beneath the input fields in the plugin's settings, to alert the user as to the proper place to make the change.

However, the warning message assumes that the constant is defined in `wp-config.php`, which may not be the case: it is possible for the constant to be defined in various places:
- `wp-config.php`
- an mu-plugin
- theme file

In my use-case, I define the constants in the theme (will probably move to an mu-plugin soon) that use the development environment, and define the production variables in production's `wp-config.php`. While this likely won't be a problem in my case (because the constants ARE defined in `wp-config.php` on production), it could very well be the case for someone else, and a removing the incorrect assumption could save a developer some time tracking things down (plus add some precision to the plugin, which is always nice).

The warning message could be changed from:

> WARNING! Container ID was set and fixed in wp-config.php. If you wish to change this value, please edit your wp-config.php and change the container ID or remove the GTM4WP_HARDCODED_GTM_ID constant!

to

> WARNING! Container ID was set and fixed by the GTM4WP_HARDCODED_GTM_ID constant. Check wp-config.php, plugins, and your theme settings to change or remove the container ID.

This PR makes the described changes to three warning messages.