### PR TITLE
Render the data span after the image wrapper

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -997,7 +997,7 @@ function gtm4wp_woocommerce_get_product_list_item_extra_tag($product, $listtype,
 	);
 }
 
-function gtm4wp_woocommerce_before_shop_loop_item() {
+function gtm4wp_woocommerce_after_shop_loop_item() {
 	global $product, $woocommerce_loop;
 
 	$listtype = "";
@@ -1147,7 +1147,7 @@ if ( function_exists( 'WC' ) ) {
 	add_filter( GTM4WP_WPFILTER_COMPILE_DATALAYER, 'gtm4wp_woocommerce_datalayer_filter_items' );
 
 	add_filter( 'loop_end', 'gtp4wp_woocommerce_reset_loop' );
-	add_action( 'woocommerce_before_shop_loop_item', 'gtm4wp_woocommerce_before_shop_loop_item' );
+	add_action( 'woocommerce_after_shop_loop_item', 'gtm4wp_woocommerce_after_shop_loop_item' );
 	add_action( 'woocommerce_after_add_to_cart_button', 'gtm4wp_woocommerce_single_add_to_cart_tracking' );
 
 	// add_action( "wp_footer", "gtm4wp_woocommerce_wp_footer" );


### PR DESCRIPTION
Shop Isle relies on nth-child(2) to hide a variant of the image set. However, by adding the product data related span before the product image via `before_shop_loop_item`, this causes the product image to become hidden. If we render the span with the `woocommerce_after_shop_loop_item` hook instead, we can preserve the span while avoiding this problem.

How it looks:
```
<li class="product type-product post-13462 status-publish first instock product_cat-foxyjoel product_cat-may-new-items product_cat-posters product_tag-damiya-foxyjoel product_tag-tokyomenace has-post-thumbnail shipping-taxable purchasable product-type-simple">
   <a href="https://shop.moso.moe/product/damiya-foxyjoel-tokyomenace/" class="woocommerce-LoopProduct-link woocommerce-loop-product__link">
      <div class="prod-img-wrap">
         <img src="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-262x405.png" class="attachment-shop_catalog size-shop_catalog wp-post-image" alt="" loading="lazy" title="JOE-01 Damiya - FoxyJoel - TokyoMenace" srcset="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-262x405.png 262w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-194x300.png 194w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-663x1024.png 663w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-768x1187.png 768w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-994x1536.png 994w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-555x858.png 555w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace.png 1056w" sizes="(max-width: 262px) 100vw, 262px" data-attachment-id="13274" data-permalink="https://shop.moso.moe/?attachment_id=13274" data-orig-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace.png" data-orig-size="1056,1632" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="JOE-01 Damiya – FoxyJoel – TokyoMenace" data-image-description="" data-medium-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-194x300.png" data-large-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-663x1024.png" width="262" height="405"><img src="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-262x405.png" class="attachment-shop_catalog size-shop_catalog" alt="" loading="lazy" srcset="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-262x405.png 262w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-194x300.png 194w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-663x1024.png 663w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-768x1187.png 768w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-994x1536.png 994w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-555x858.png 555w, https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace.png 1056w" sizes="(max-width: 262px) 100vw, 262px" data-attachment-id="13274" data-permalink="https://shop.moso.moe/?attachment_id=13274" data-orig-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace.png" data-orig-size="1056,1632" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="JOE-01 Damiya – FoxyJoel – TokyoMenace" data-image-description="" data-medium-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-194x300.png" data-large-file="https://shop.moso.moe/wp-content/uploads/2021/05/JOE-01-Damiya-FoxyJoel-TokyoMenace-663x1024.png" width="262" height="405">
         <div class="product-button-wrap">
            <div class="add-to-cart-button-wrap">
   <a href="?add-to-cart=13462" data-quantity="1" class="button product_type_simple add_to_cart_button ajax_add_to_cart" data-product_id="13462" data-product_sku="JOE-01" aria-label="Add “Damiya - FoxyJoel - TokyoMenace” to your cart" rel="nofollow">Add to cart</a></div></div></div>
   <h2 class="woocommerce-loop-product__title">Damiya – FoxyJoel – TokyoMenace</h2>
   <span class="price"><span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">$</span>10.00</bdi></span></span>
   </a><span class="gtm4wp_productdata" style="display:none; visibility:hidden;" data-gtm4wp_product_id="13462" data-gtm4wp_product_name="Damiya - FoxyJoel - TokyoMenace" data-gtm4wp_product_price="10" data-gtm4wp_product_cat="Posters" data-gtm4wp_product_url="https://shop.moso.moe/product/damiya-foxyjoel-tokyomenace/" data-gtm4wp_product_listposition="1" data-gtm4wp_productlist_name="General Product List" data-gtm4wp_product_stocklevel="9" data-gtm4wp_product_brand=""></span>
</li>
```

Classic Selector:

```
		var productdata = jQuery( this ).closest( '.product' ).find( '.gtm4wp_productdata' );
```

Enhanced Selector:

```
		var temp_selector = jQuery( this ).closest( '.product,.wc-block-grid__product' );
		var dom_productdata = '';

		if ( temp_selector.length > 0 ) {
			dom_productdata = temp_selector.find( '.gtm4wp_productdata' );

		} else {
			temp_selector = jQuery( this ).closest( '.products li' );

			if ( temp_selector.length > 0 ) {
				dom_productdata = temp_selector.find( '.gtm4wp_productdata' );

			} else {
				temp_selector = jQuery( this ).closest( '.products>div' );

				if ( temp_selector.length > 0 ) {
					dom_productdata = temp_selector.find( '.gtm4wp_productdata' );

				} else {
					temp_selector = jQuery( this ).closest( '.woocommerce-grouped-product-list-item__label' );

					if ( temp_selector.length > 0 ) {
						dom_productdata = temp_selector.find( '.gtm4wp_productdata' );
					} else {
						dom_productdata = jQuery( this );
					}
				}
			}
		}
```

In both scenarios, we're still nested within the element with the `product` class so there will be no impact on the query.