### PR TITLE
enhanced ecommerce - unset global state var

### DIFF
--- a/js/gtm4wp-woocommerce-enhanced.js
+++ b/js/gtm4wp-woocommerce-enhanced.js
@@ -746,9 +746,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						'items': [ gtm4wp_map_eec_to_ga4( product_data ) ]
 					},
 					'eventCallback': function() {
-
+						delete window[ "gtm4wp_select_item_" + product_data.id ];
 						if ( ctrl_key_pressed && productpage_window ) {
-							productpage_window.location.href= dom_productdata.getAttribute( 'data-gtm4wp_product_url' );
+							productpage_window.location.href = dom_productdata.getAttribute( 'data-gtm4wp_product_url' );
 						} else {
 							document.location.href = dom_productdata.getAttribute( 'data-gtm4wp_product_url' );
 						}


### PR DESCRIPTION
unset the state variable `window[ "gtm4wp_select_item_" + product_data.id ]` before changing location. This is needed on e.g. Safari: If we don't unset this variable, it will be cached / will stay on true if going back with the browser's back button / `history.back()`. This in consequence made it impossible to revisit a certain item. The commit fixes this.