### PR TITLE
A11y update on iframe

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -538,7 +538,7 @@ function gtm4wp_get_the_gtm_tag() {
 		foreach ( $_gtm_codes as $one_gtm_code ) {
 			$_gtm_tag .= '
 <noscript><iframe src="https://' . $_gtm_domain_name . '/ns.html?id=' . $one_gtm_code . $_gtm_env . '"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
+height="0" width="0" style="display:none;visibility:hidden" aria-hidden="true"></iframe></noscript>';
 		}
 
 		$_gtm_tag .= '


### PR DESCRIPTION
To satisfy WCAG `Success Criterion 4.1.2: Name, Role, Value`

Hiding this iframe from assistive technologies as it provides no functionality for the end user. This will also alleviate a11y audit warnings.