### PR TITLE
Fixed html5 support detection

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -603,7 +603,7 @@ function gtm4wp_wp_footer() {
 
 		if ( $user_logged_in ) {
 			echo "
-<script" . ( $has_html5_support ? ' type="text/javascript"' : '' ) . ">
+<script" . ( $has_html5_support ? '' : ' type="text/javascript"' ) . ">
 	if ( window.dataLayer ) {
 		window.dataLayer.push({
 			'event': 'gtm4wp.userLoggedIn'
@@ -622,7 +622,7 @@ function gtm4wp_wp_footer() {
 
 		if ( $user_registered ) {
 			echo "
-<script" . ( $has_html5_support ? ' type="text/javascript"' : '' ) . ">
+<script" . ( $has_html5_support ? '' : ' type="text/javascript"' ) . ">
 	if ( window.dataLayer ) {
 		window.dataLayer.push({
 			'event': 'gtm4wp.userRegistered'


### PR DESCRIPTION
I fixed the order of the if/else statement to include the type="text/javascript" when html5 is NOT supported. In the existing version the type="text/javascript" was added for websites that support HTML5 and removed for websites that do not.