### PR TITLE
Added additional post day name & post date time fields in ISO8601 and Unix format

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -204,6 +204,11 @@ function gtm4wp_add_basic_datalayer_data( $dataLayer ) {
 			$dataLayer['pagePostDateYear']  = get_the_date( 'Y' );
 			$dataLayer['pagePostDateMonth'] = get_the_date( 'm' );
 			$dataLayer['pagePostDateDay']   = get_the_date( 'd' );
+			$dataLayer['pagePostDateDayName']   = get_the_date( 'l' );
+			$dataLayer['pagePostDateHour']   = get_the_date( 'H' );
+			$dataLayer['pagePostDateMinute']   = get_the_date( 'i' );
+			$dataLayer['pagePostDateIso']   = get_the_date( 'c' );
+			$dataLayer['pagePostDateUnix']   = get_the_date( 'U' );
 		}
 
 		if ( $gtm4wp_options[ GTM4WP_OPTION_INCLUDE_POSTTERMLIST ] ) {


### PR DESCRIPTION
I added these fields so that they could possibly be used as custom dimensions, metrics, events, etc in Google Analytics, BigQuery, etc, so that site owners could potentially use this data to determine the best day and time to post new posts, etc.

The following are new fields:

- pagePostDateDayName
- pagePostDateHour
- pagePostDateMinute
- pagePostDateIso
- pagePostDateUnix