### PR TITLE
Modify comparison operator used to check "_ga_tracked" key

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -840,7 +840,7 @@ function gtm4wp_woocommerce_datalayer_filter_items( $data_layer ) {
 			);
 		}
 
-		if ( ( 1 === get_post_meta( $order_id, '_ga_tracked', true ) ) && ! $do_not_flag_tracked_order ) {
+		if ( ( 1 == get_post_meta( $order_id, '_ga_tracked', true ) ) && ! $do_not_flag_tracked_order ) {
 			unset( $order );
 		}
 
@@ -1012,7 +1012,7 @@ function gtm4wp_woocommerce_thankyou( $order_id ) {
 	}
 
 	$do_not_flag_tracked_order = (bool) ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_WCNOORDERTRACKEDFLAG ] );
-	if ( ( 1 === get_post_meta( $order_id, '_ga_tracked', true ) ) && ! $do_not_flag_tracked_order ) {
+	if ( ( 1 == get_post_meta( $order_id, '_ga_tracked', true ) ) && ! $do_not_flag_tracked_order ) {
 		unset( $order );
 	}
 


### PR DESCRIPTION
In source code you are using identical operator for checking "_ga_tracked" is enabled or not. It will be failed always as **woocommerce** returns the meta value as **string**.

Source code: 
`if( 1 === get_post_meta( $order_id, '_ga_tracked', true ) )`

get_post_meta returns only string value, so that identical operator (===) is gives false result. If we use equality operator (==) then it will gives true result.

Updated code:
`if( 1 == get_post_meta( $order_id, '_ga_tracked', true ) )`



This will fix the issue #236 
