### PR TITLE
fix "event.target.closest is not a function"

### DIFF
--- a/js/gtm4wp-form-move-tracker.js
+++ b/js/gtm4wp-form-move-tracker.js
@@ -1,5 +1,5 @@
 document.addEventListener("focusin", function(event) {
-	const elem = event && event.target && event.target.closest("input,select,textarea,button,meter,progress");
+	const elem = event && event.target && event.target.closest && event.target.closest("input,select,textarea,button,meter,progress");
 	if ( elem ) {
 		window[ gtm4wp_datalayer_name ].push({
 			'event'    : 'gtm4wp.formElementEnter',
@@ -16,7 +16,7 @@ document.addEventListener("focusin", function(event) {
 }, false);
 
 document.addEventListener("focusout", function(event) {
-	const elem = event && event.target && event.target.closest("input,select,textarea,button,meter,progress");
+	const elem = event && event.target && event.target.closest && event.target.closest("input,select,textarea,button,meter,progress");
 	if ( elem ) {
 		window[ gtm4wp_datalayer_name ].push({
 			'event'    : 'gtm4wp.formElementLeave',


### PR DESCRIPTION
I have gtm4wp installed on my site, and I get a lot of `event.target.closest is not a function` errors.
in "Additional Data" it says:
```javascript
[
  {
    currentTarget: [object HTMLDocument], 
    isTrusted: False, 
    target: [object HTMLDocument], 
    type: focusin
  }
]
```

and indeed - `HTMLDocument` doesn't have a `closest` function.
(try opening devtools and type `document.closest`).

Surprisingly this happens in Chrome.
I don't know when and why this happens, but when it does - the function fails and throws an error,
so I'd rather it failing silently.

Screenshots from my Sentry issue:
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/1780369/191925793-5f7f9640-8a6a-4b8d-9703-2b5eef9024f5.png">

<img width="756" alt="image" src="https://user-images.githubusercontent.com/1780369/191925839-9b3f8484-4373-4d8c-ab1d-ae38042cba1d.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/1780369/191925942-b3e963cd-07f1-4a03-a96c-5092d2e1c7c9.png">
