### PR TITLE
Fix undefined is_returning_customer

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -423,7 +423,7 @@ function gtm4wp_get_purchase_datalayer( $order, $order_items ) {
 		 *
 		 * @see https://support.google.com/google-ads/answer/9917012?hl=en-AU#zippy=%2Cinstall-with-google-tag-manager
 		 */
-		$data_layer['new_customer'] = $order->is_returning_customer() === false;
+		$data_layer['new_customer'] = \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore::is_returning_customer($order) === false;
 
 		if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_WCEXCLUDETAX ] ) {
 			$order_revenue = (float) ( $order->get_total() - $order->get_total_tax() );


### PR DESCRIPTION
Fixes #282 $order->is_returning_customer() being undefined function.

In this context, $order is instance of WC_Order, while the method is_returning_customer() is only available in Order class which extends WC_Order.

WC_Order is available in both frontend and backend, but Order is used in Admin only - analytics. This PR reuses the return value of is_returning_customer in Order, which is basically directly calling DataStore with static method.