### PR TITLE
Enable to apply filters on woocommerce order items

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -349,7 +349,7 @@ function gtm4wp_process_order_items( $order ) {
 				continue;
 			}
 
-			$product       = $item->get_product();
+			$product       = apply_filters('woocommerce_order_item_product', $item->get_product(), $item);
 			$inc_tax       = ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) );
 			$product_price = round( (float) $order->get_item_total( $item, $inc_tax ), 2 );
 


### PR DESCRIPTION
This filter enables to modify the order items used for the GA4 "purchase" event after a woocommerce order has been placed. In my case, I wanted to transform the product data in all GA4 ecommerce dataLayer events.

I noticed a similar filter (`woocommerce_cart_item_product`) already exists to enable modifications of product data for cart-level dataLayer events. Basically, this enables exactly the same but on the thank you / order complete page.