### PR TITLE
Feature: Add order argument

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -355,7 +355,7 @@ function gtm4wp_woocommerce_get_purchase_datalayer( $order, $order_items = null 
 	 *
 	 * @param array $data_layer An associative array containing the full data layer including purchase header attributes.
 	 */
-	return apply_filters( GTM4WP_WPFILTER_ECC_PURCHASE_DATALAYER, $data_layer );
+	return apply_filters( GTM4WP_WPFILTER_ECC_PURCHASE_DATALAYER, $data_layer, $order );
 }
 
 /**

--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -296,6 +296,7 @@ function gtm4wp_woocommerce_get_raw_order_datalayer( $order, $order_items ) {
 	 * Can be used to add custom order or even product data into the data layer.
 	 *
 	 * @param array  $order_data An associative array containing all data (head data and products) about the currently placed order.
+	 * @param WC_Order $order       The WooCommerce order object.
 	 */
 	return apply_filters( GTM4WP_WPFILTER_EEC_ORDER_DATA, $order_data, $order );
 }
@@ -354,6 +355,7 @@ function gtm4wp_woocommerce_get_purchase_datalayer( $order, $order_items = null 
 	 * Can be used to add custom data to the data layer when the purhcase ecommerce action is included.
 	 *
 	 * @param array $data_layer An associative array containing the full data layer including purchase header attributes.
+	 * @param WC_Order $order The WooCommerce order that needs to be transformed into an enhanced ecommerce data layer.
 	 */
 	return apply_filters( GTM4WP_WPFILTER_ECC_PURCHASE_DATALAYER, $data_layer, $order );
 }

--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -297,7 +297,7 @@ function gtm4wp_woocommerce_get_raw_order_datalayer( $order, $order_items ) {
 	 *
 	 * @param array  $order_data An associative array containing all data (head data and products) about the currently placed order.
 	 */
-	return apply_filters( GTM4WP_WPFILTER_EEC_ORDER_DATA, $order_data );
+	return apply_filters( GTM4WP_WPFILTER_EEC_ORDER_DATA, $order_data, $order );
 }
 /**
  * Takes a WooCommerce order and order items and generates the standard/classic and


### PR DESCRIPTION
The proposed modification aims to enhance the `GTM4WP_WPFILTER_ECC_PURCHASE_DATALAYER` and `GTM4WP_WPFILTER_EEC_ORDER_DATA` filters by including the WooCommerce order data.

Currently, while utilizing the `GTM4WP_WPFILTER_EEC_ORDER_DATA` filter, developers encounter limitations when attempting to enrich the data layer with additional information. Specifically, the absence of the order ID within this filter poses a challenge, requiring developers to resort to backtracking procedures to retrieve the order ID using order numbers.

This would be achieved by adding the `$order` argument to the filter, which would enable developers to access complete order data when modifying data layer values. The addition of the order object alongside the existing data layer would allow users to customize tracking and analytics implementations based on specific order attributes and requirements, thereby improving tracking efficiency.