### PR TITLE
perf (frontend): add defer attribute to gtm script

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -1122,7 +1122,7 @@ function gtm4wp_wp_header_begin( $echo = true ) {
 <script data-cfasync="false"' . ( $add_cookiebot_ignore ? ' data-cookieconsent="ignore"' : '' ) . '>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':
 new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=
+j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.defer=true;j.src=
 \'//' . esc_js( $_gtm_domain_name ) . '/' . esc_js( $_gtm_domain_path ) . '?id=\'+i+dl' .
 			( ( ( '' !== $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_AUTH ] ) && ( '' !== $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_PREVIEW ] ) ) ? "+'&gtm_auth=" . esc_attr( $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_AUTH ] ) . '&gtm_preview=' . esc_attr( $gtm4wp_options[ GTM4WP_OPTION_ENV_GTM_PREVIEW ] ) . "&gtm_cookies_win=x'" : '' ) . ';f.parentNode.insertBefore(j,f);
 })(window,document,\'script\',\'' . esc_js( $gtm4wp_datalayer_name ) . '\',\'' . esc_js( $one_gtm_id ) . '\');


### PR DESCRIPTION
Hi @duracelltomi ,

I have a performance issue on Lighthouse concerning the blocking loading of the script `googletagmanager.com/gtm.js` which is loaded in the `<head>`.

To resolve this performance issue, you would simply add the `defer` attribute to the `<script>` element.

I haven't found any other way currently in the code to add it through a parameter.

I'm not sure if adding this attribute has any impact on GTM but from what I've tested, it still seems to work well.