### PR TITLE
Fix deprecated warning and update function comment

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -46,10 +46,10 @@ function gtm4wp_woocommerce_add_global_vars( $return ) {
  *
  * @see https://developers.google.com/analytics/devguides/collection/ua/gtm/enhanced-ecommerce
  *
- * @param WP_Product $product An instance of WP_Product that needs to be transformed into an enhanced ecommerce product object.
- * @param array      $additional_product_attributes Any key-value pair that needs to be added into the enhanced ecommerce product object.
- * @param string     $attributes_used_for The placement ID of the product that is passed to the apply_filters hook so that 3rd party code can be notified where this product data is being used.
- * @return array The enhanced ecommerce product object of the WooCommerce product.
+ * @param WP_Product   $product An instance of WP_Product that needs to be transformed into an enhanced ecommerce product object.
+ * @param array        $additional_product_attributes Any key-value pair that needs to be added into the enhanced ecommerce product object.
+ * @param string       $attributes_used_for The placement ID of the product that is passed to the apply_filters hook so that 3rd party code can be notified where this product data is being used.
+ * @return array|false The enhanced ecommerce product object of the WooCommerce product, or false if the product does not exist.
  */
 function gtm4wp_woocommerce_process_product( $product, $additional_product_attributes, $attributes_used_for ) {
 	global $gtm4wp_options;
@@ -1262,6 +1262,10 @@ function gtm4wp_woocommerce_get_product_list_item_extra_tag( $product, $listtype
 		),
 		'productlist'
 	);
+
+	if ( $eec_product_array === false ) {
+		return false;
+	}
 
 	if ( ! isset( $eec_product_array['item_brand'] ) ) {
 		$eec_product_array['item_brand'] = '';


### PR DESCRIPTION
Fixes PHP Deprecated:  Automatic conversion of false to array is deprecated in /www/any/wp-content/plugins/duracelltomi-google-tag-manager/integration/woocommerce.php on line 1265 by returning if the function returns false. Updates documentation to explain that function can return false.