### PR TITLE
Fix purchase event

### DIFF
--- a/integration/woocommerce.php
+++ b/integration/woocommerce.php
@@ -783,7 +783,7 @@ function gtm4wp_woocommerce_thankyou( $order_id ) {
 
 		// Check whether this order has been already tracked before in this browser.
 		let gtm4wp_order_already_tracked = false;
-		if ( gtm4wp_orderid_tracked && ( ' . esc_js( $order->get_order_number() ) . ' == gtm4wp_orderid_tracked ) ) {
+		if ( gtm4wp_orderid_tracked && ( "' . esc_js( $order->get_order_number() ) . '" == gtm4wp_orderid_tracked ) ) {
 			gtm4wp_order_already_tracked = true;
 		}
 
@@ -798,9 +798,9 @@ function gtm4wp_woocommerce_thankyou( $order_id ) {
 			var gtm4wp_orderid_cookie_expire = new Date();
 			gtm4wp_orderid_cookie_expire.setTime( gtm4wp_orderid_cookie_expire.getTime() + (365*24*60*60*1000) );
 			var gtm4wp_orderid_cookie_expires_part = "expires=" + gtm4wp_orderid_cookie_expire.toUTCString();
-			document.cookie = "gtm4wp_orderid_tracked=" + ' . esc_js( $order->get_order_number() ) . ' + ";" + gtm4wp_orderid_cookie_expires_part + ";path=/";
+			document.cookie = "gtm4wp_orderid_tracked=" + "' . esc_js( $order->get_order_number() ) . '" + ";" + gtm4wp_orderid_cookie_expires_part + ";path=/";
 		} else {
-			window.localStorage.setItem( "gtm4wp_orderid_tracked", ' . esc_js( $order->get_order_number() ) . ' );
+			window.localStorage.setItem( "gtm4wp_orderid_tracked", "' . esc_js( $order->get_order_number() ) . '" );
 		}
 </script>';
 


### PR DESCRIPTION
Fixes #320 and probably #328.

The JS to push the purchase event to the dataLayer produces errors because the order id is not inserted as a string. See screenshot:

![Bildschirm­foto 2024-09-17 um 14 19 44](https://github.com/user-attachments/assets/ac955118-c1c9-4c4a-9fe5-a78bd3c3ecd6)
