### PR TITLE
Fix current_product_detail_data.variant

### DIFF
--- a/js/gtm4wp-woocommerce.js
+++ b/js/gtm4wp-woocommerce.js
@@ -527,7 +527,7 @@ function gtm4wp_woocommerce_process_pages() {
 		for( let attrib_key in product_variation.attributes ) {
 			product_variation_attribute_values.push( product_variation.attributes[ attrib_key ] );
 		}
-		current_product_detail_data.variant = product_variation_attribute_values.join(',');
+		current_product_detail_data.item_variant = product_variation_attribute_values.join(',');
 		gtm4wp_last_selected_product_variation = current_product_detail_data;
 
 		delete current_product_detail_data.internal_id;


### PR DESCRIPTION
Related to https://github.com/duracelltomi/gtm4wp/issues/377

> Hi, we are using GTM4WP v. 1.20.2 and in the `view_item` event, the `variant` key seems to be using the wrong naming convention, as it should be `item_variant`.
> 
> The key `cartContent.items[n].item_variant` seems correct instead.
> If there are any other details I can provide, please let me know.
> 
> The line should be this one:
> https://github.com/duracelltomi/gtm4wp/blob/766dc45c883dbdeaf3887c8a0556e0abbfa4d91d/js/gtm4wp-woocommerce.js#L530

![image](https://github.com/user-attachments/assets/f7908d13-4808-4228-9917-9c8a39baeb71)
