### PR TITLE
fix: allow add_to_cart tracking even when .disabled class is present – fixes #407

### DIFF
--- a/js/gtm4wp-woocommerce.js
+++ b/js/gtm4wp-woocommerce.js
@@ -205,12 +205,12 @@ function gtm4wp_woocommerce_process_pages() {
 	// manage events related to user clicks
 	document.addEventListener( 'click', function( e ) {
 		let event_target_element = e.target;
-	
+
 		if ( !event_target_element ) {
 			// for some reason event target is not specificed
 			return true;
 		}
-	
+
 		// track add to cart events for simple products in product lists
 		if ( event_target_element.closest( '.add_to_cart_button:not(.product_type_variable, .product_type_grouped, .single_add_to_cart_button)' ) ) {
 			const product_el = event_target_element.closest( '.product,.wc-block-grid__product' );
@@ -240,11 +240,11 @@ function gtm4wp_woocommerce_process_pages() {
 				'value': productdata.price
 			});
 		}
-	
+
 		// track add to cart events for products on product detail pages
 		const add_to_cart_button = event_target_element.closest( '.single_add_to_cart_button' );
 		if ( add_to_cart_button ) {
-			if (add_to_cart_button.hasclass( 'disabled' ) || add_to_cart_button.disabled) {
+			if (add_to_cart_button.classList.contains( 'disabled' ) || add_to_cart_button.disabled) {
 				// do not track clicks on disabled buttons
 				return true;
 			}
@@ -253,15 +253,15 @@ function gtm4wp_woocommerce_process_pages() {
 			if ( !product_form ) {
 				return true;
 			}
-	
+
 			let product_variant_id = product_form.querySelectorAll( '[name=variation_id]' );
 			let product_is_grouped = product_form.classList && product_form.classList.contains( 'grouped_form' );
-	
+
 			if ( product_variant_id.length > 0 ) {
 				if ( gtm4wp_last_selected_product_variation ) {
 					const qty_el = product_form.querySelector( '[name=quantity]' );
 					gtm4wp_last_selected_product_variation.quantity = (qty_el && qty_el.value) || 1;
-	
+
 					gtm4wp_push_ecommerce( 'add_to_cart', [ gtm4wp_last_selected_product_variation ], {
 						'currency': gtm4wp_currency,
 						'value': (gtm4wp_last_selected_product_variation.price * gtm4wp_last_selected_product_variation.quantity).toFixed(2)
@@ -271,7 +271,7 @@ function gtm4wp_woocommerce_process_pages() {
 				const products_in_group = document.querySelectorAll( '.grouped_form .gtm4wp_productdata' );
 				let products = [];
 				let sum_value = 0;
-	
+
 				products_in_group.forEach( function( product_data_el ) {
 					const productdata = gtm4wp_read_json_from_node(product_data_el, 'gtm4wp_product_data', ['productlink']);
 					if ( !productdata ) {
@@ -285,22 +285,22 @@ function gtm4wp_woocommerce_process_pages() {
 					} else {
 						return true;
 					}
-	
+
 					if ( 0 == product_qty ) {
 						return true;
 					}
 					productdata.quantity = product_qty;
 
 					delete productdata.internal_id;
-	
+
 					products.push( productdata );
 					sum_value += productdata.price * productdata.quantity;
 				});
-	
+
 				if ( 0 == products.length ) {
 					return true;
 				}
-	
+
 				gtm4wp_push_ecommerce( 'add_to_cart', products, {
 					'currency': gtm4wp_currency,
 					'value': sum_value.toFixed(2)
@@ -316,18 +316,18 @@ function gtm4wp_woocommerce_process_pages() {
 				if ( isNaN( productdata.quantity ) ) {
 					productdata.quantity = 1;
 				}
-	
+
 				gtm4wp_push_ecommerce( 'add_to_cart', [ productdata ], {
 					'currency': gtm4wp_currency,
 					'value': productdata.price * productdata.quantity
 				});
 			}
 		}
-	
+
 		// track remove links in mini cart widget and on cart page
 		if ( event_target_element.closest( '.mini_cart_item a.remove,.product-remove a.remove' ) ) {
 			const click_el = event_target_element;
-	
+
 			const productdata_el = click_el && click_el.closest( '.mini_cart_item a.remove,.product-remove a.remove' );
 			if ( !productdata_el ) {
 				return true;
@@ -346,7 +346,7 @@ function gtm4wp_woocommerce_process_pages() {
 				qty_element = mini_cart_item_el && mini_cart_item_el.querySelectorAll( '.quantity' );
 				if ( qty_element && ( qty_element.length > 0 ) ) {
 					qty = parseInt( qty_element[0].textContent );
-	
+
 					if ( Number.isNaN( qty ) ) {
 						qty = 0;
 					}
@@ -354,19 +354,19 @@ function gtm4wp_woocommerce_process_pages() {
 			} else {
 				qty = qty_element[0].value;
 			}
-	
+
 			if ( 0 === qty ) {
 				return true;
 			}
 
 			productdata.quantity = qty;
-	
+
 			gtm4wp_push_ecommerce( 'remove_from_cart', [ productdata ], {
 				'currency': gtm4wp_currency,
 				'value': productdata.price * productdata.quantity
 			});
 		}
-	
+
 		// track clicks in product lists
 		if ( event_target_element.closest(
 			'.products li:not(.product-category) a:not(.add_to_cart_button):not(.quick-view-button),'
@@ -379,7 +379,7 @@ function gtm4wp_woocommerce_process_pages() {
 			if ( 'undefined' == typeof google_tag_manager ) {
 				return true;
 			}
-	
+
 			const event_target_element = e.target;
 			const matching_link_element = event_target_element.closest(
 				'.products li:not(.product-category) a:not(.add_to_cart_button):not(.quick-view-button),'
@@ -388,32 +388,32 @@ function gtm4wp_woocommerce_process_pages() {
 				+'.widget-product-item,'
 				+'.woocommerce-grouped-product-list-item__label a'
 			);
-	
+
 			if ( !matching_link_element ) {
 				return true;
 			}
-	
+
 			let temp_selector = event_target_element.closest( '.product,.wc-block-grid__product' );
 			let productdata_el;
-	
+
 			if ( temp_selector ) {
 				productdata_el = temp_selector.querySelector( '.gtm4wp_productdata' );
-	
+
 			} else {
 				temp_selector = event_target_element.closest( '.products li' );
-	
+
 				if ( temp_selector ) {
 					productdata_el = temp_selector.querySelector( '.gtm4wp_productdata' );
-	
+
 				} else {
 					temp_selector = event_target_element.closest( '.products>div' );
-	
+
 					if ( temp_selector ) {
 						productdata_el = temp_selector.querySelector( '.gtm4wp_productdata' );
-	
+
 					} else {
 						temp_selector = event_target_element.closest( '.woocommerce-grouped-product-list-item__label' );
-	
+
 						if ( temp_selector ) {
 							productdata_el = temp_selector.querySelector( '.gtm4wp_productdata' );
 						} else {
@@ -422,17 +422,17 @@ function gtm4wp_woocommerce_process_pages() {
 					}
 				}
 			}
-			
+
 			const productdata = gtm4wp_read_json_from_node( productdata_el, 'gtm4wp_product_data', ['internal_id'] );
 			if ( !productdata ) {
 				return true;
 			}
-	
+
 			// only act on links pointing to the product detail page
 			if ( productdata.productlink != matching_link_element.getAttribute( 'href' ) ) {
 				return true;
 			}
-	
+
 			// Look at first GTM container ID in case there are multiple GTM containers live on the page
 			// since eventCallback is called on every container and we only need this executed once in this case.
 			for (let i in window.google_tag_manager) {
@@ -441,22 +441,22 @@ function gtm4wp_woocommerce_process_pages() {
 					break;
 				}
 			}
-	
+
 			// do not do anything if GTM was not loaded
 			// and window.google_tag_manager is for some reason initialized (GA4 only setup?)
 			if ( "" === window.gtm4wp_first_container_id ) {
 				return true;
 			}
-	
+
 			const ctrl_key_pressed = e.ctrlKey || e.metaKey;
 			const target_new_tab = ( '_blank' === matching_link_element.target );
-			
+
 			// save this info to prevent redirection if another plugin already prevented to event for some reason
 			let event_already_prevented = e.defaultPrevented;
 			if ( !event_already_prevented ) {
 				e.preventDefault();
 			}
-			
+
 			if ( ctrl_key_pressed || target_new_tab ) {
 				// we need to open the new tab/page here so that popup blocker of the browser doesn't block our code
 				window.productpage_window = window.open( 'about:blank', '_blank' );
@@ -464,7 +464,7 @@ function gtm4wp_woocommerce_process_pages() {
 
 			const productlink_to_redirect = productdata.productlink;
 			delete productdata.productlink;
-	
+
 			let datalayer_timeout = 2000;
 			if (window.gtm4wp_datalayer_max_timeout) {
 				datalayer_timeout = window.gtm4wp_datalayer_max_timeout;
@@ -489,7 +489,7 @@ function gtm4wp_woocommerce_process_pages() {
 			},
 			datalayer_timeout);
 		}
-	});
+	}, { capture: true } );
 
 	// track variable products on their detail pages
 	// currently, we need to use jQuery here since WooCommerce is firing this event using jQuery
@@ -675,7 +675,7 @@ function gtm4wp_woocommerce_process_pages() {
 			}
 		});
 	}
-};
+}
 
 function gtm4wp_woocommerce_page_loading_completed() {
 	document.removeEventListener( "DOMContentLoaded", gtm4wp_woocommerce_page_loading_completed );


### PR DESCRIPTION
This PR fixes #407, where the `add_to_cart` event is not triggered when using Bricks Builder due to the `.single_add_to_cart_button:not(.disabled)` selector.

Bricks (and potentially other themes/builders) applies the `.disabled` class to the add to cart button during loading for visual feedback. As a result, the GTM4WP plugin's selector fails to detect clicks during this state when the `.disabled` class is added before the GTM4WP code is run.

### Changes made:
- Removed the `:not(.disabled)` condition from the click selector.
- Minified the JS code using `npm run build`.
- Verified that the `add_to_cart` event still fires only once per click, as browsers naturally block click events on actually disabled buttons.

This change improves compatibility while maintaining existing click-handling logic.