### PR TITLE
fix: add JSON_HEX_AMP/QUOT/APOS to prevent esc_attr XSS regression

### DIFF
--- a/public/frontend.php
+++ b/public/frontend.php
@@ -1137,7 +1137,7 @@ function gtm4wp_wp_header_begin( $echo = true ) {
 		$gtm4wp_datalayer_data = (array) apply_filters( GTM4WP_WPFILTER_COMPILE_DATALAYER, $gtm4wp_datalayer_data );
 
 		$script_tag .= '
-	var dataLayer_content = ' . wp_json_encode( $gtm4wp_datalayer_data, JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_HEX_TAG ) . ';';
+	var dataLayer_content = ' . wp_json_encode( $gtm4wp_datalayer_data, JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS ) . ';';
 
 		$script_tag .= '
 	' . esc_js( $gtm4wp_datalayer_name ) . '.push( dataLayer_content );';
@@ -1388,7 +1388,7 @@ function gtm4wp_fire_additional_datalayer_pushes() {
 
 		if ( array_key_exists( 'datalayer_object', $one_event ) ) {
 			$datalayer_push_code .= '
-	' . esc_js( $gtm4wp_datalayer_name ) . '.push(' . wp_json_encode( $one_event['datalayer_object'], JSON_UNESCAPED_UNICODE | JSON_HEX_TAG ) . ');';
+	' . esc_js( $gtm4wp_datalayer_name ) . '.push(' . wp_json_encode( $one_event['datalayer_object'], JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS ) . ');';
 		}
 
 		if ( array_key_exists( 'js_after', $one_event ) ) {

--- a/tests/test-json-encode-script-context.php
+++ b/tests/test-json-encode-script-context.php
@@ -250,6 +250,48 @@ class Test_JSON_Encode_Script_Context extends TestCase {
 	}
 
 	/**
+	 * Regression test for PR #432: esc_attr entities survive full pipeline
+	 *
+	 * esc_attr() converts " to &quot;, which htmlspecialchars_decode() decodes
+	 * back to " unless JSON_HEX_AMP prevents entity formation.
+	 */
+	public function test_esc_attr_entity_survives_full_pipeline() {
+		$raw_input     = 'test"breakout';
+		$after_esc_attr = esc_attr( $raw_input ); // test&quot;breakout
+
+		$data   = array( 'siteSearchTerm' => $after_esc_attr );
+		$json   = wp_json_encode(
+			$data,
+			JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS
+		);
+		$output = htmlspecialchars_decode( $json );
+
+		$decoded = json_decode( $output, true );
+		$this->assertNotNull( $decoded, 'esc_attr entity must not break JSON after htmlspecialchars_decode' );
+	}
+
+	/**
+	 * Regression test for PR #432: XSS exploit payload via esc_attr pipeline
+	 *
+	 * Verifies the actual exploit `/?s=%22%7D%3Balert(1)%2F%2F` is neutralised.
+	 */
+	public function test_xss_payload_via_esc_attr_pipeline() {
+		$raw_input     = '"};alert(1)//';
+		$after_esc_attr = esc_attr( $raw_input );
+
+		$data   = array( 'siteSearchTerm' => $after_esc_attr );
+		$json   = wp_json_encode(
+			$data,
+			JSON_UNESCAPED_UNICODE | JSON_NUMERIC_CHECK | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS
+		);
+		$output = htmlspecialchars_decode( $json );
+
+		$decoded = json_decode( $output, true );
+		$this->assertNotNull( $decoded, 'XSS payload via esc_attr must not break JSON' );
+		$this->assertStringNotContainsString( '";alert', $output, 'Must not contain unescaped XSS payload' );
+	}
+
+	/**
 	 * Test: Long payload performance
 	 *
 	 * Ensures the fix handles large search terms efficiently


### PR DESCRIPTION
## Summary

- Add `JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS` to both `wp_json_encode()` calls in `public/frontend.php` (L1140, L1391)
- Add two regression tests covering the `esc_attr()` → `wp_json_encode()` → `htmlspecialchars_decode()` pipeline

> Authored by **Aether AI Agent** — commit 7c6a8e6

## Problem

PR #432 removed `htmlspecialchars()` but relied only on `JSON_HEX_TAG`. The `esc_attr()` call converts `"` → `&quot;`, which `htmlspecialchars_decode()` at L1149 decodes back to `"`, breaking JSON string boundaries — reflected XSS via `/?s=%22%7D%3Balert(1)%2F%2F`.

## Fix

`JSON_HEX_AMP` encodes `&` as `\u0026`, preventing entity formation entirely. `JSON_HEX_QUOT` and `JSON_HEX_APOS` add defense-in-depth for quote characters.

## Test plan

- [ ] Both new regression tests pass with fix applied
- [ ] All 28 existing tests pass
- [ ] Exploit `/?s=%22%7D%3Balert(1)%2F%2F` produces valid JSON (no XSS)