### PR TITLE
feat: add native Axeptio CMP integration with Google Consent Mode v2

### DIFF
--- a/admin/admin-tab-integrate.php
+++ b/admin/admin-tab-integrate.php
@@ -297,4 +297,42 @@ $GLOBALS['gtm4wp_integratefieldtexts'] = array(
 		'plugintocheck' => 'webtoffee-gdpr-cookie-consent/cookie-law-info.php',
 	),
 
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO                  => array(
+		'label'       => esc_html__( 'Axeptio', 'duracelltomi-google-tag-manager' ),
+		'description' => esc_html__(
+			'Enable this to let GTM4WP load the Axeptio CMP SDK directly. No separate Axeptio plugin is required.
+			Enter your Axeptio project ID and cookies version below.',
+			'duracelltomi-google-tag-manager'
+		),
+		'phase'       => GTM4WP_PHASE_STABLE,
+	),
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID        => array(
+		'label'       => esc_html__( 'Axeptio Project ID', 'duracelltomi-google-tag-manager' ),
+		'description' => esc_html__(
+			'Your Axeptio project identifier, passed to the SDK as the clientId. You can find it in your Axeptio dashboard.',
+			'duracelltomi-google-tag-manager'
+		),
+		'phase'       => GTM4WP_PHASE_STABLE,
+	),
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION  => array(
+		'label'       => esc_html__( 'Cookies version', 'duracelltomi-google-tag-manager' ),
+		'description' => esc_html__(
+			'The cookies version (cookiesVersion) loaded by the SDK. The list is fetched automatically from your Axeptio
+			project once a valid Project ID is set above.',
+			'duracelltomi-google-tag-manager'
+		),
+		'phase'       => GTM4WP_PHASE_STABLE,
+	),
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_CONSENTMODE      => array(
+		'label'       => esc_html__( 'Enable Google Consent Mode v2', 'duracelltomi-google-tag-manager' ),
+		'description' => esc_html__(
+			'When enabled, Axeptio drives Google Consent Mode v2: it fires both the "default" (everything denied) and the
+			"update" commands using its certified vendor mapping. Use this instead of the plugin\'s own "Google Consent Mode"
+			feature, and do not enable both. A dedicated dataLayer event (gtm4wp.axeptioConsentUpdate) is also pushed
+			whenever the visitor updates their choices.',
+			'duracelltomi-google-tag-manager'
+		),
+		'phase'       => GTM4WP_PHASE_STABLE,
+	),
+
 );

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -427,6 +427,22 @@ function gtm4wp_admin_output_field( $args ) {
 			}
 
 			break;
+
+		case GTM4WP_OPTIONS . '[' . GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION . ']':
+			$axeptio_cookies_version = $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION ];
+
+			echo '<select id="' . esc_attr( GTM4WP_OPTIONS . '[' . GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION . ']' ) . '" name="' . esc_attr( GTM4WP_OPTIONS . '[' . GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION . ']' ) . '" data-selected-version="' . esc_attr( $axeptio_cookies_version ) . '">';
+			// Pre-render the saved value so it survives a save even if the version list cannot be fetched.
+			if ( '' !== $axeptio_cookies_version ) {
+				echo '<option value="' . esc_attr( $axeptio_cookies_version ) . '" selected="selected">' . esc_html( $axeptio_cookies_version ) . '</option>';
+			}
+			echo '</select><br />';
+			echo '<span class="axeptio_cookies_version_error"></span>';
+
+			echo gtm4wp_safe_admin_html_with_links( $args['description'] ); // phpcs:ignore
+
+			break;
+
 		default:
 			if ( preg_match( '/' . GTM4WP_OPTIONS . '\\[blacklist\\-[^\\]]+\\]/i', $args['label_for'] ) ) {
 				if ( 'blacklist-sandboxed' === $args['entityid'] ) {
@@ -617,6 +633,13 @@ function gtm4wp_sanitize_options( $options ) {
 			} else {
 				$output[ $optionname ] = $newoptionvalue;
 			}
+		} elseif (
+			GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID === $optionname
+			|| GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION === $optionname
+		) {
+			// Must run before the generic "integrate-" branch below, otherwise these free-text values get cast to boolean.
+			$output[ $optionname ] = sanitize_text_field( $newoptionvalue );
+
 		} elseif ( substr( $optionname, 0, 10 ) === 'integrate-' ) {
 			// integrations.
 			$output[ $optionname ] = (bool) $newoptionvalue;
@@ -1055,6 +1078,7 @@ function gtm4wp_add_admin_js( $hook ) {
 			'misctabtitle'          => esc_html__( 'Misc', 'duracelltomi-google-tag-manager' ),
 			'consentmodetabtitle'   => esc_html__( 'Google Consent Mode', 'duracelltomi-google-tag-manager' ),
 			'webtoffeetabtitle'     => esc_html__( 'WebToffee GDPR Cookie Consent', 'duracelltomi-google-tag-manager' ),
+			'axeptiotabtitle'       => esc_html__( 'Axeptio', 'duracelltomi-google-tag-manager' ),
 		);
 		wp_localize_script( 'admin-subtabs', 'gtm4wp', $subtabtexts );
 
@@ -1062,6 +1086,14 @@ function gtm4wp_add_admin_js( $hook ) {
 
 		// phpcs ignore set due to in_footer set to true does not load the script.
 		wp_enqueue_script( 'admin-tabcreator', $gtp4wp_plugin_url . 'js/admin-tabcreator.js', array( 'jquery' ), GTM4WP_VERSION ); // phpcs:ignore
+
+		$axeptiotexts = array(
+			'non_existing_account_id' => esc_html__( 'We were unable to find your Axeptio project, or it has not been published yet.', 'duracelltomi-google-tag-manager' ),
+			'verification_error'      => esc_html__( 'Error while fetching the Axeptio project versions. Please try again.', 'duracelltomi-google-tag-manager' ),
+		);
+		wp_register_script( 'admin-axeptio', $gtp4wp_plugin_url . 'js/admin-axeptio.js', array(), GTM4WP_VERSION ); // phpcs:ignore
+		wp_localize_script( 'admin-axeptio', 'gtm4wpAxeptio', $axeptiotexts );
+		wp_enqueue_script( 'admin-axeptio' );
 
 		wp_enqueue_style( 'gtm4wp-admin-css', $gtp4wp_plugin_url . 'css/admin-gtm4wp.css', array(), GTM4WP_VERSION );
 	}
@@ -1084,6 +1116,7 @@ function gtm4wp_admin_head() {
 	.datalayername_validation_error,
 	.gtmauth_validation_error,
 	.gtmpreview_validation_error,
+	.axeptio_cookies_version_error,
 	.gtm_wpconfig_set	{
 		color: #c00;
 		font-weight: bold;
@@ -1094,7 +1127,8 @@ function gtm4wp_admin_head() {
 	.ampid_validation_error,
 	.datalayername_validation_error,
 	.gtmauth_validation_error,
-	.gtmpreview_validation_error {
+	.gtmpreview_validation_error,
+	.axeptio_cookies_version_error {
 		display: none;
 	}
 </style>

--- a/common/readoptions.php
+++ b/common/readoptions.php
@@ -99,6 +99,12 @@ define( 'GTM4WP_OPTION_INTEGRATE_COOKIEBOT', 'integrate-cookiebot' );
 
 define( 'GTM4WP_OPTION_INTEGRATE_WEBTOFFEE_GDPR', 'integrate-webtoffee-gdpr' );
 
+define( 'GTM4WP_OPTION_INTEGRATE_AXEPTIO', 'integrate-axeptio' );
+define( 'GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID', 'integrate-axeptio-projectid' );
+define( 'GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION', 'integrate-axeptio-cookies-version' );
+define( 'GTM4WP_OPTION_INTEGRATE_AXEPTIO_CONSENTMODE', 'integrate-axeptio-consent-mode' );
+define( 'GTM4WP_WPFILTER_AXEPTIO_CONSENT_MODE_DEFAULT', 'gtm4wp_axeptio_consent_mode_default' );
+
 define( 'GTM4WP_OPTION_INTEGRATE_CONSENTMODE', 'integrate-consent-mode' );
 define( 'GTM4WP_OPTION_INTEGRATE_CONSENTMODE_ADS', 'integrate-consent-mode-ads' );
 define( 'GTM4WP_OPTION_INTEGRATE_CONSENTMODE_AD_USER_DATA', 'integrate-consent-mode-ad-user-data' );
@@ -207,6 +213,11 @@ $gtm4wp_defaultoptions = array(
 	GTM4WP_OPTION_INTEGRATE_COOKIEBOT                => false,
 
 	GTM4WP_OPTION_INTEGRATE_WEBTOFFEE_GDPR           => false,
+
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO                  => false,
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID        => '',
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION  => '',
+	GTM4WP_OPTION_INTEGRATE_AXEPTIO_CONSENTMODE      => false,
 
 	GTM4WP_OPTION_INTEGRATE_CONSENTMODE              => false,
 	GTM4WP_OPTION_INTEGRATE_CONSENTMODE_ADS          => false,

--- a/css/admin-gtm4wp.css
+++ b/css/admin-gtm4wp.css
@@ -70,3 +70,8 @@
 .gtm4wp-phase-deprecated:before {
 	content: "deprecated";
 }
+
+/* Hide the Axeptio configuration */
+.form-table:has( #gtm4wp-options\[integrate-axeptio\]:not(:checked) ) tr:has( [id^="gtm4wp-options[integrate-axeptio-"] ) {
+	display: none !important;
+}

--- a/integration/axeptio.php
+++ b/integration/axeptio.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Axeptio CMP integration for gtm4wp: loads the SDK, optionally drives Google Consent Mode v2,
+ * and bridges consent choices to the data layer.
+ *
+ * @package GTM4WP
+ */
+
+/**
+ * Builds the Consent Mode v2 default state (all denied) handed over to the Axeptio SDK.
+ *
+ * @return array
+ */
+function gtm4wp_axeptio_get_consent_mode_default() {
+	$consent_default = array(
+		'analytics_storage'  => 'denied',
+		'ad_storage'         => 'denied',
+		'ad_user_data'       => 'denied',
+		'ad_personalization' => 'denied',
+		'wait_for_update'    => 500,
+	);
+
+	/**
+	 * Filters the Consent Mode v2 default, e.g. to grant signals for non-GDPR audiences.
+	 *
+	 * @param array $consent_default
+	 */
+	return apply_filters( GTM4WP_WPFILTER_AXEPTIO_CONSENT_MODE_DEFAULT, $consent_default );
+}
+
+/**
+ * Builds the window.axeptioSettings object injected before the Axeptio SDK.
+ *
+ * @return array
+ */
+function gtm4wp_axeptio_get_settings() {
+	global $gtm4wp_options;
+
+	$settings = array(
+		'clientId' => $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID ],
+	);
+
+	$cookies_version = $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_COOKIES_VERSION ];
+	if ( '' !== $cookies_version ) {
+		$settings['cookiesVersion'] = $cookies_version;
+	}
+
+	if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_CONSENTMODE ] ) {
+		$settings['googleConsentMode'] = array(
+			'default' => gtm4wp_axeptio_get_consent_mode_default(),
+		);
+	}
+
+	return $settings;
+}
+
+/**
+ * Outputs the Axeptio settings, SDK loader and data layer bridge.
+ *
+ * Hooked early (priority 1) so the consent default is set before the GTM container and Google tags load.
+ *
+ * @return void
+ */
+function gtm4wp_axeptio_wp_head() {
+	global $gtm4wp_datalayer_name;
+
+	$axeptio_settings = wp_json_encode(
+		gtm4wp_axeptio_get_settings(),
+		JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS
+	);
+
+	$data_layer_name = esc_js( $gtm4wp_datalayer_name );
+
+	$script_tag = '
+' . gtm4wp_generate_script_opening_tag() . '
+	window.axeptioSettings = ' . $axeptio_settings . ';
+
+	window._axcb = window._axcb || [];
+	window._axcb.push(function(axeptio) {
+		axeptio.on("cookies:complete", function(choices) {
+			window.' . $data_layer_name . ' = window.' . $data_layer_name . ' || [];
+			window.' . $data_layer_name . '.push({
+				"event": "gtm4wp.axeptioConsentUpdate",
+				"axeptioChoices": choices
+			});
+		});
+	});
+
+	(function(d, s) {
+		var t = d.getElementsByTagName(s)[0], e = d.createElement(s);
+		e.async = true;
+		e.src = "https://static.axept.io/sdk.js";
+		t.parentNode.insertBefore(e, t);
+	})(document, "script");
+</script>';
+
+	echo htmlspecialchars_decode( // phpcs:ignore
+		wp_kses(
+			$script_tag,
+			gtm4wp_get_sanitize_script_block_rules()
+		)
+	);
+}
+add_action( 'wp_head', 'gtm4wp_axeptio_wp_head', 1, 0 );

--- a/js/admin-axeptio.js
+++ b/js/admin-axeptio.js
@@ -1,0 +1,65 @@
+/**
+ * GTM4WP Axeptio admin settings.
+ *
+ * Fills the cookies version <select> with the versions published for the configured Axeptio project,
+ * so the value can be picked from the real list instead of being typed by hand.
+ */
+document.addEventListener( 'DOMContentLoaded', () => {
+	const projectIdInput = document.getElementById( 'gtm4wp-options[integrate-axeptio-projectid]' );
+	const versionSelect  = document.getElementById( 'gtm4wp-options[integrate-axeptio-cookies-version]' );
+	const errorMessage   = document.querySelector( '.axeptio_cookies_version_error' );
+
+	if ( ! projectIdInput || ! versionSelect ) {
+		return;
+	}
+
+	const showError = ( message ) => {
+		if ( errorMessage ) {
+			errorMessage.textContent = message;
+			errorMessage.style.display = message ? 'block' : '';
+		}
+	};
+
+	const fillVersions = ( cookies ) => {
+		const selectedVersion = versionSelect.dataset.selectedVersion || '';
+		const titlesByName = new Map(
+			cookies.filter( ( cookie ) => cookie.name ).map( ( cookie ) => [ cookie.name, cookie.title || cookie.name ] )
+		);
+
+		versionSelect.replaceChildren(
+			...[ ...titlesByName ].map( ( [ name, title ] ) => new Option( title, name, false, name === selectedVersion ) )
+		);
+	};
+
+	const loadVersions = () => {
+		const projectId = projectIdInput.value.trim();
+		showError( '' );
+
+		if ( ! projectId ) {
+			return;
+		}
+
+		fetch( `https://client.axept.io/${ encodeURIComponent( projectId ) }.json?nocache=${ Date.now() }` )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					throw new Error( 'Network response was not ok' );
+				}
+
+				return response.json();
+			} )
+			.then( ( data ) => {
+				if ( data.cookies && data.cookies.length ) {
+					fillVersions( data.cookies );
+				} else {
+					showError( gtm4wpAxeptio.non_existing_account_id );
+				}
+			} )
+			.catch( () => showError( gtm4wpAxeptio.verification_error ) );
+	};
+
+	projectIdInput.addEventListener( 'change', loadVersions );
+
+	if ( projectIdInput.value.trim() ) {
+		loadVersions();
+	}
+} );

--- a/js/admin-subtabs.js
+++ b/js/admin-subtabs.js
@@ -75,6 +75,10 @@ var adminsubtabs = {
 		"int-webtoffeegdpr": {
 			tabtext: gtm4wp.webtoffeetabtitle,
 			numitems: 1
+		},
+		"int-axeptio": {
+			tabtext: gtm4wp.axeptiotabtitle,
+			numitems: 4
 		}
 	}
 };

--- a/public/frontend.php
+++ b/public/frontend.php
@@ -1203,7 +1203,12 @@ function gtm4wp_wp_header_begin( $echo = true ) {
 		}
 	}
 
-	if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_CONSENTMODE ] ) {
+	// When Axeptio handles Consent Mode v2, it already fires the consent default, so GTM4WP must not fire its own.
+	$axeptio_handles_consent_mode = $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO ]
+		&& ( '' !== $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID ] )
+		&& $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_AXEPTIO_CONSENTMODE ];
+
+	if ( $gtm4wp_options[ GTM4WP_OPTION_INTEGRATE_CONSENTMODE ] && ! $axeptio_handles_consent_mode ) {
 		$script_tag = '
 ' . gtm4wp_generate_script_opening_tag() . '
 		if (typeof gtag == "undefined") {
@@ -1471,6 +1476,14 @@ if (
 	&& version_compare( WC()->version, '5.0', '>=' )
 ) {
 	require_once dirname( __FILE__ ) . '/../integration/woocommerce.php';
+}
+
+if (
+	isset( $GLOBALS['gtm4wp_options'] )
+	&& $GLOBALS['gtm4wp_options'][ GTM4WP_OPTION_INTEGRATE_AXEPTIO ]
+	&& '' !== $GLOBALS['gtm4wp_options'][ GTM4WP_OPTION_INTEGRATE_AXEPTIO_PROJECTID ]
+) {
+	require_once dirname( __FILE__ ) . '/../integration/axeptio.php';
 }
 
 if ( isset( $GLOBALS['gtm4wp_options'] ) && ( $GLOBALS['gtm4wp_options'][ GTM4WP_OPTION_EVENTS_USERLOGIN ] ) ) {


### PR DESCRIPTION
## Add native Axeptio CMP integration

Hi 👋 — I'm a developer at [Axeptio](https://www.axept.io/). This PR adds a first-class Axeptio integration to GTM4WP so site owners can run Axeptio **directly through this plugin, without installing a separate Axeptio plugin**.

### Why

Axeptio is a Google-certified CMP that natively supports **Google Consent Mode v2** — it fires both the `default` and `update` commands with a certified vendor mapping. Letting GTM4WP load and wire Axeptio means consent and tag management live in one place, with no plugin collision.

### What's included

A new **"Axeptio" sub-tab** under *Integration* with:

- **Enable** toggle
- **Project ID** (the Axeptio `clientId`).
- **Cookies version** — a `<select>` auto-populated from the project's published versions (fetched from `client.axept.io`), so it can be picked instead of typed.
- **Enable Google Consent Mode v2** toggle.

### Behaviour

- The Axeptio SDK is injected early in `<head>` (priority 1) so the consent default is set before the GTM container and Google tags load.
- When **Consent Mode v2** is enabled, Axeptio drives both the `default` (all denied) and the `update` commands. GTM4WP **suppresses its own consent default** in that case to avoid sending it twice. This follows the plugin's existing guidance (*"do not enable the native Google Consent Mode feature if your CMP fires both commands"*).
- On every consent change, a **`gtm4wp.axeptioConsentUpdate`** event is pushed to the data layer (carrying the Axeptio choices) for use as a GTM trigger — consistent with the plugin's `gtm4wp.*` event convention.

### Developer hooks

- `gtm4wp_axeptio_consent_mode_default` — filter the default consent state (e.g. to grant signals for non-GDPR audiences).

### Compatibility & quality

- Fully backward compatible: nothing changes unless the integration is enabled.
- Follows the plugin conventions (option keys, `GTM4WP_*` constants, settings rendering/sanitization, `wp_kses` script output, sub-tab system).
- All strings are translation-ready (`duracelltomi-google-tag-manager` text domain; JS strings localized via `wp_localize_script`).
- PHP `7.4+`, JS aligned with the repo ESLint config (ES6).

### Testing

Verified end-to-end in the browser with a live Axeptio project:

- **Refuse** → `gtag('consent','update')` all denied → Google requests carry `gcs=G100` (`npa=1`).
- **Accept** → all granted → `gcs=G111` (`npa=0`).
- `gtm4wp.axeptioConsentUpdate` fires with the real consent choices in both cases; no double `consent default`.