### PR TITLE
Repoint CI to master/1.x and refresh branch-topology docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,8 +31,8 @@ test-quality sibling of the security system above (same shape, so the two align)
 
 ## Architecture
 
-Version 2.0 is a full OOP rewrite (see the 2.0-dev branch). The public 1.x
-integration surface — hooks, template functions, wp-config constants and the
+Version 2.0 is a full OOP rewrite (this `master` branch; the released 1.x line
+lives on the `1.x` branch). The public 1.x integration surface — hooks, template functions, wp-config constants and the
 `gtm4wp-options` key — is kept backward compatible through the `compat/` layer.
 
 - **Namespaced OOP PHP** — PSR-4 `GTM4WP\` → `src/`, one class per file, autoloaded via `src/Autoloader.php` (Composer autoloader used for tests). No global procedural code except the `compat/` shims.

--- a/.claude/commands/wporg-forum-review.md
+++ b/.claude/commands/wporg-forum-review.md
@@ -131,12 +131,13 @@ is settled — do not restate the error because it sounds plausible.
 
 Run the skill's [fix-status resolver](../skills/wporg-forum-triage/SKILL.md) **once per
 sweep**, not once per topic: pull the published version from the wordpress.org API, read
-`git show master:CHANGELOG.md` for the released 1.x fixes, and `git show
-2.0-dev:CHANGELOG.md` for the `## 2.0` section. Hold both lists in mind while classifying.
+`git show 1.x:CHANGELOG.md` for the released 1.x fixes, and `git show
+master:CHANGELOG.md` for the `## 2.0` section. Hold both lists in mind while classifying.
 
-The trap worth repeating: `CHANGELOG.md` on the checked-out `2.0-dev` branch has **no
-1.22.x section**. Reading fix status off the current branch will tell a reporter to wait
-for 2.0 when the fix is already downloadable.
+The trap worth repeating: `CHANGELOG.md` on the checked-out `master` branch (the 2.0 line)
+has **no 1.22.x section** — it jumps from `## 2.0` straight to `## 1.21.1`. The released 1.x
+fixes live on the `1.x` branch. Reading fix status off the current branch will tell a
+reporter to wait for 2.0 when the fix is already downloadable.
 
 ### 3. Assign a lane
 

--- a/.claude/skills/github-issue-triage/SKILL.md
+++ b/.claude/skills/github-issue-triage/SKILL.md
@@ -95,7 +95,7 @@ gh issue list --state all --search "<key terms>" --limit 20 \
 ```
 
 - Search `CHANGELOG.md` and recent commits for the symptom — on the 2.0 rewrite,
-  many open 1.x bugs are already fixed on `2.0-dev`. Use `git log --oneline
+  many open 1.x bugs are already fixed on `master`. Use `git log --oneline
   --all --grep=<term>` and `Grep` over `CHANGELOG.md`.
 - If it duplicates another issue → outcome **duplicate** (link the canonical one).
 - If it's fixed but unreleased → draft a comment naming the fixing commit/PR and
@@ -279,7 +279,7 @@ comment asks for.
 
 ## Quick reference
 
-- Repo: `duracelltomi/gtm4wp` · default branch `master` · active dev `2.0-dev`
+- Repo: `duracelltomi/gtm4wp` · default branch `master` (the active 2.0 line) · released 1.x maintenance on `1.x`
 - **Read `.support/forum-answers.md` before drafting** — the FAQ of canonical answers,
   shared with the wordpress.org forum system, carrying the traps a previous run already
   fell into. Reuse an entry or add one, every run. Git-ignored, so it is a safe place

--- a/.claude/skills/wporg-forum-triage/SKILL.md
+++ b/.claude/skills/wporg-forum-triage/SKILL.md
@@ -24,7 +24,7 @@ for one topic or an ad-hoc handful.
 | Write access | `gh issue comment/close/edit` | **None.** No API; replying requires a logged-in session |
 | Labels / state | real labels | **none** — state lives in the local `.support/` ledger |
 | Reply window | forever | **~6 months of inactivity, then the topic is closed to replies** |
-| Who the reporter is | usually a developer | usually a site owner on the **released 1.x**, not on `2.0-dev` |
+| Who the reporter is | usually a developer | usually a site owner on the **released 1.x**, not on the `master` 2.0 rewrite |
 | Automated replies | fine | **prohibited** — the forum guidelines ban "unvetted AI-generated responses" |
 
 The hard rules:
@@ -58,7 +58,7 @@ The hard rules:
    plugin on the right side of the guidelines — a human vets every word.
 
 3. **Answer for the version the reporter is actually running.** Almost every forum
-   reporter is on the released 1.x line. "Fixed on `2.0-dev`" is not an answer to
+   reporter is on the released 1.x line. "Fixed on `master` (2.0)" is not an answer to
    someone whose site is broken today. Always run the
    [fix-status resolver](#2-fix-status-resolver) before drafting.
 
@@ -108,9 +108,9 @@ The highest-value reply on this forum is "that's already fixed — update." Gett
 right needs both branches, because **the branch you are checked out on does not have the
 whole story**:
 
-- `master` — the released 1.x line (final release **1.22.4**). Its `CHANGELOG.md` holds
+- `1.x` — the released 1.x line (final release **1.22.4**). Its `CHANGELOG.md` holds
   the `## 1.22.4` and earlier sections.
-- `2.0-dev` — the rewrite. Its `CHANGELOG.md` has a `## 2.0` section and then jumps
+- `master` — the 2.0 rewrite. Its `CHANGELOG.md` has a `## 2.0` section and then jumps
   straight to `## 1.21.1`; **there is no 1.22.x section on this branch at all.** Fixes
   backported to 1.22.4 are invisible from here.
 
@@ -121,15 +121,15 @@ Resolve in order and stop at the first hit:
 curl -s "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request\[slug\]=duracelltomi-google-tag-manager" \
   | python -c "import sys,json; d=json.load(sys.stdin); print(d['version'], d['last_updated'])"
 
-# 2. Fixed in a released 1.x version?  (authoritative — read master, not the current branch)
-git show master:CHANGELOG.md | sed -n '/^## 1.22.4/,/^## 1.21.1/p'
-git show master:readme.txt | grep -i "stable tag"
+# 2. Fixed in a released 1.x version?  (authoritative — read the 1.x branch, not the current branch)
+git show 1.x:CHANGELOG.md | sed -n '/^## 1.22.4/,/^## 1.21.1/p'
+git show 1.x:readme.txt | grep -i "stable tag"
 
-# 3. Fixed on master but not yet released?
-git log master --oneline --grep=<term>
+# 3. Fixed on the 1.x branch but not yet released?
+git log 1.x --oneline --grep=<term>
 
 # 4. Fixed only in the rewrite?
-git show 2.0-dev:CHANGELOG.md | sed -n '/^## 2.0/,/^## 1.21.1/p'
+git show master:CHANGELOG.md | sed -n '/^## 2.0/,/^## 1.21.1/p'
 ```
 
 | Outcome | What the reply says |
@@ -377,7 +377,7 @@ Trim to what is actually missing:
 - Plugin slug: `duracelltomi-google-tag-manager` · forum: `https://wordpress.org/support/plugin/duracelltomi-google-tag-manager/`
 - Maintainer login: `duracelltomi` (the only contributor listed on wordpress.org). Anyone
   else in a thread is a reporter or a bystander.
-- Branches: `master` = released 1.x (1.22.4, final 1.x) · `2.0-dev` = the rewrite
+- Branches: `1.x` = released 1.x line (1.22.4, final 1.x) · `master` = the 2.0 rewrite (default branch)
 - Reply window: ~6 months of inactivity, then closed. `age_days > 150` = answer it now.
 - Apology threshold: 14 days with no maintainer reply
 - Security channel: `security@gtm4wp.com` / GitHub private advisories (`SECURITY.md`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ 2.0-dev ]
+    branches: [ master, 1.x ]
   pull_request:
-    branches: [ 2.0-dev ]
+    branches: [ master, 1.x ]
 
 jobs:
   php:


### PR DESCRIPTION
## Why

The `master` ⟷ `2.0-dev` topology flipped: **`master` is now the 2.0 rewrite**, and the **released 1.x line lives on the `1.x` branch**. Two classes of references were left describing the old world:

1. **CI was watching a dead branch.** `.github/workflows/ci.yml` triggered only on `2.0-dev`, so pushes/PRs to `master` (and `1.x`) ran **no** phpcs/phpunit/JS checks at all.
2. **`.claude` docs/skills** still called `2.0-dev` the "active dev" branch and `master` the "released 1.x" line — the reverse of reality, including the forum fix-status resolver that reads `CHANGELOG.md` from the wrong branch.

## Changes

- **`ci.yml`** — trigger on `[ master, 1.x ]`.
- **`CLAUDE.md`** — the 2.0 rewrite is `master`; released 1.x is the `1.x` branch.
- **`wporg-forum-triage` / `wporg-forum-review`** — fix-status lookups now read released fixes from `1.x:CHANGELOG.md` and the `## 2.0` section from `master:CHANGELOG.md` (verified: `master` jumps `## 2.0` → `## 1.21.1` with no 1.22.x; `1.x` holds `## 1.22.4`).
- **`github-issue-triage`** — "already fixed on `master`"; quick-reference topology corrected.

No production code touched, so no CHANGELOG entry (`[skip changelog]`).

> Note: this PR won't itself get a CI run — the *current* `master` workflow still keys on `2.0-dev`. CI starts firing on subsequent pushes/PRs once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)