### PR TITLE
Verify and declare WordPress 7.0 / WooCommerce 10.9.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Major rewrite of the plugin - please read the announcement post on gtm4wp.com be
 
 * Changed: complete object-oriented rewrite. Every feature is now a module that third-party plugins can extend through the `gtm4wp_register_modules` action. All public template functions (`gtm4wp_the_gtm_tag()` etc.), filter/action names, wp-config constants and the `gtm4wp-options` storage key are unchanged, so existing integrations keep working.
 * Changed: minimum requirements raised to PHP 8.0 and WordPress 6.3.
+* Updated: verified compatible with WordPress 7.0.2 and WooCommerce 10.9.4.
 * Updated: frontend scripts now load with the `defer` strategy where possible.
 
 ### Settings screen

--- a/duracelltomi-google-tag-manager-for-wordpress.php
+++ b/duracelltomi-google-tag-manager-for-wordpress.php
@@ -22,7 +22,7 @@
  * Domain Path: /languages
 
  * WC requires at least: 5.0
- * WC tested up to: 10.6.1
+ * WC tested up to: 10.9.4
  */
 
 // This file must stay parseable on outdated PHP versions so that the

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://gtm4wp.com/
 Tags: google tag manager, tag manager, gtm, google ads, google analytics
 Requires at least: 6.3
 Requires PHP: 8.0
-Tested up to: 6.9.4
+Tested up to: 7.0.2
 Stable tag: 1.22.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html


### PR DESCRIPTION
## Summary
- Verified the plugin against WordPress 7.0.2 and WooCommerce 10.9.4 (both newer than the previously declared "tested up to" versions)
- Bumped `readme.txt`'s `Tested up to` header (6.9.4 → 7.0.2) and the main plugin file's `WC tested up to` header (10.6.1 → 10.9.4)
- Added a CHANGELOG.md bullet under Architecture & requirements

## Test plan
- [x] Activated the plugin against a live WordPress 7.0.2 + WooCommerce 10.9.4 site via WP-CLI
- [x] Enabled `WP_DEBUG`/`WP_DEBUG_LOG` and hit the front page, a product page, and the cart page — `dataLayer` renders correctly on all three, zero PHP notices/warnings/deprecations logged
- [x] `vendor/bin/phpunit` — 588 tests / 2060 assertions, green
- [x] `php -l` on the modified main plugin file — no syntax errors
- [x] Restored the test site's `wp-config.php` debug settings afterward